### PR TITLE
Add market-map.html: interactive CMMC services market map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Static site hosted on GitHub Pages. Four HTML pages, no build tools.
 | `index.html` | Homepage — hero (A/B tested), services, frameworks, social proof, contact form |
 | `about.html` | About page — expertise, clients, approach |
 | `discovery.html` | SSP intake form — Tally.so embed, unlisted (noindex), shared via direct URL |
+| `market-map.html` | Public interactive market map of the CMMC services landscape (89 entities, periodic-table layout). Linked from all page footers. |
 | `privacy.html` | Privacy policy — includes PostHog tracking disclosure |
 | `logo.png` | Logo (also: `Geometric Eagle Head Logo.png`) |
 | `CNAME` | Custom domain: `eagleridge.io` |

--- a/about.html
+++ b/about.html
@@ -240,6 +240,7 @@
             <p>
                 <a href="/">Home</a>
                 <a href="/about.html">About</a>
+                <a href="/market-map.html">Market Map</a>
                 <a href="/privacy.html">Privacy Policy</a>
                 <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 <a href="mailto:contact@eagleridge.io">Contact</a>

--- a/index.html
+++ b/index.html
@@ -511,6 +511,7 @@
         <div class="container">
             <p>
                 <a href="/about.html" style="color: #3d2817; text-decoration: none; margin: 0 12px;">About</a>
+                <a href="/market-map.html" style="color: #3d2817; text-decoration: none; margin: 0 12px;">Market Map</a>
                 <a href="/privacy.html" style="color: #3d2817; text-decoration: none; margin: 0 12px;">Privacy Policy</a>
                 <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer" style="color: #3d2817; text-decoration: none; margin: 0 12px;">LinkedIn</a>
                 <a href="mailto:contact@eagleridge.io" style="color: #3d2817; text-decoration: none; margin: 0 12px;">Contact</a>

--- a/llms.txt
+++ b/llms.txt
@@ -6,6 +6,7 @@
 
 - [Homepage](https://eagleridge.io/): Services overview, compliance frameworks, and contact form
 - [About](https://eagleridge.io/about.html): Expertise, client types, and consulting approach
+- [Market Map](https://eagleridge.io/market-map.html): Eagle Ridge's view of the CMMC services market — 89 firms and platforms mapped by category, with the 0→1 readiness gap for DIB SMBs called out
 - [Privacy Policy](https://eagleridge.io/privacy.html): Data handling and analytics disclosure
 
 ## Services

--- a/market-map.html
+++ b/market-map.html
@@ -1,0 +1,740 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The GRC market map | Eagle Ridge Advisory</title>
+<meta name="description" content="Eagle Ridge Advisory's read of the CMMC services market — 89 firms and platforms mapped by category, with the 0&rarr;1 readiness gap for DIB SMBs called out.">
+<link rel="canonical" href="https://eagleridge.io/market-map.html">
+<meta property="og:title" content="The GRC market map — Eagle Ridge Advisory">
+<meta property="og:description" content="Mapping competition, capacity, and the 0→1 readiness gap for DIB SMBs in the CMMC services market.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://eagleridge.io/market-map.html">
+<meta property="og:image" content="https://eagleridge.io/logo.png">
+<script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('phc_gKgLr0iMjD1gnLV3yd8lEYWIUWmkIk8BuI6jUG3rTBg', {
+        api_host: 'https://us.i.posthog.com',
+        person_profiles: 'identified_only',
+        loaded: function(posthog) {
+            posthog.register({ site: 'eagleridge.io' });
+            console.log('PostHog loaded');
+        }
+    });
+</script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.4.0/dist/tabler-icons.min.css">
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    color: #3d2817;
+    background: #f9f6ec;
+    line-height: 1.6;
+  }
+
+  .site-header {
+    padding: 32px 0;
+    border-bottom: 1px solid #d0cdb8;
+    background: #f9f6ec;
+  }
+  .site-header-inner { max-width: 1200px; margin: 0 auto; padding: 0 24px; }
+  .site-logo {
+    display: inline-flex; align-items: center; gap: 12px;
+    font-size: 24px; font-weight: 600; color: #3d2817;
+    letter-spacing: -0.5px; text-decoration: none;
+  }
+  .site-logo img { width: 40px; height: 40px; }
+
+  .map-body {
+    background: #fafaf8;
+    color: #1a1a1a;
+    font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 15px;
+    line-height: 1.55;
+  }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 32px 24px 64px; }
+
+  header.page { padding: 0 0 24px; margin-bottom: 32px; border-bottom: 1px solid #e5e5e5; }
+  header.page h1 { font-size: 28px; font-weight: 600; margin: 0 0 6px; letter-spacing: -0.01em; color: #1a1a1a; }
+  header.page p.subtitle { margin: 0; color: #525252; font-size: 15px; }
+  header.page p.meta { margin: 12px 0 0; font-size: 12px; color: #737373; }
+
+  section.lead { margin: 0 0 32px; }
+  section.lead p { margin: 0 0 12px; font-size: 15px; line-height: 1.65; color: #2a2a2a; }
+  section.lead p.first-mile { font-size: 17px; color: #1a1a1a; line-height: 1.55; }
+
+  .controls { display: flex; gap: 10px; margin: 0 0 14px; align-items: center; flex-wrap: wrap; }
+  .controls input[type="text"] {
+    flex: 1; min-width: 200px; height: 36px; padding: 0 12px;
+    border: 1px solid #d4d4d4; border-radius: 8px;
+    font-family: inherit; font-size: 14px; color: #1a1a1a; background: #ffffff;
+  }
+  .controls input[type="text"]:focus { outline: none; border-color: #1a1a1a; box-shadow: 0 0 0 2px rgba(0,0,0,0.08); }
+  .controls button {
+    height: 36px; padding: 0 14px;
+    border: 1px solid #d4d4d4; border-radius: 8px;
+    background: #ffffff; color: #1a1a1a;
+    font-family: inherit; font-size: 13px; font-weight: 500;
+    cursor: pointer;
+  }
+  .controls button:hover { background: #f5f5f3; }
+  .controls button:active { transform: scale(0.98); }
+
+  .legend { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 0 18px; font-size: 11px; }
+  .legend-item {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 4px 9px;
+    border-radius: 8px; cursor: pointer;
+    border: 1px solid #e5e5e5; background: #ffffff;
+    user-select: none; color: #2a2a2a;
+    transition: opacity 0.15s ease;
+    font: inherit; margin: 0;
+    appearance: none; -webkit-appearance: none;
+  }
+  .legend-item:hover { border-color: #cccccc; }
+  .legend-item:focus-visible { outline: 2px solid #1a1a1a; outline-offset: 2px; }
+  .legend-item.dim { opacity: 0.35; }
+  .legend-dot { width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0; }
+
+  .periodic { display: grid; grid-template-columns: repeat(18, 1fr); grid-auto-rows: 40px; gap: 3px; margin: 4px 0 12px; }
+  .series-label { font-size: 11px; color: #525252; margin: 14px 0 5px; font-weight: 500; letter-spacing: 0.02em; text-transform: uppercase; }
+  .series { display: grid; grid-template-columns: repeat(18, 1fr); grid-auto-rows: 40px; gap: 3px; }
+
+  .el {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    border-radius: 3px; border: 1px solid;
+    cursor: pointer; position: relative;
+    transition: transform 0.12s ease;
+    overflow: hidden;
+    /* button reset (cells are native &lt;button&gt; for keyboard a11y) */
+    font: inherit; padding: 0; margin: 0;
+    appearance: none; -webkit-appearance: none;
+  }
+  .el:hover { transform: scale(1.18); z-index: 5; box-shadow: 0 1px 6px rgba(0,0,0,0.18); }
+  .el:focus-visible { outline: 2px solid #1a1a1a; outline-offset: 2px; z-index: 5; }
+  .el.dim { opacity: 0.35; pointer-events: none; }
+  .el.selected { outline: 2px solid #1a1a1a; outline-offset: 1px; z-index: 4; }
+  .el .num { position: absolute; top: 2px; right: 3px; font-size: 7px; font-weight: 400; opacity: 0.7; line-height: 1; }
+  .el .sym { font-size: 12px; font-weight: 600; line-height: 1; }
+  .el.gap { border-style: dashed; border-width: 2px; animation: pulse 2.4s ease-in-out infinite; }
+  .el.gap .sparkle { position: absolute; top: -1px; left: 2px; font-size: 9px; color: #854F0B; }
+  @keyframes pulse { 0%,100% { box-shadow: 0 0 0 0 rgba(186,117,23,0.6); } 50% { box-shadow: 0 0 0 5px rgba(186,117,23,0); } }
+
+  .mobile-view { display: none; }
+  .mobile-view .mobile-hint { font-size: 12px; color: #525252; margin: 0 0 12px; font-style: italic; }
+  .mobile-view .mobile-cat-group { margin-bottom: 18px; }
+  .mobile-view .mobile-cat-label {
+    font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+    color: #525252; margin: 0 0 6px;
+  }
+  .mobile-view .mobile-cells { display: flex; flex-wrap: wrap; gap: 6px; }
+  .mobile-view .mobile-cell {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid;
+    background: #ffffff;
+    cursor: pointer;
+    font-size: 13px;
+    font-family: inherit;
+  }
+  .mobile-view .mobile-cell:active { transform: scale(0.97); }
+  .mobile-view .mobile-cell:focus-visible { outline: 2px solid #1a1a1a; outline-offset: 2px; }
+  .mobile-view .mobile-cell .sym {
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 3px;
+    border: 1px solid;
+    font-size: 11px;
+  }
+  .mobile-view .mobile-cell.gap { border-style: dashed; }
+
+  .detail {
+    margin: 18px 0 0;
+    padding: 18px 20px;
+    background: #ffffff;
+    border: 1px solid #e5e5e5; border-radius: 12px;
+    display: none;
+  }
+  .detail.show { display: block; }
+  .detail-header { display: flex; align-items: center; gap: 14px; margin-bottom: 14px; }
+  .detail-sym {
+    width: 64px; height: 64px;
+    border-radius: 8px; border: 1px solid;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    position: relative; flex-shrink: 0;
+  }
+  .detail-sym .num { position: absolute; top: 4px; right: 6px; font-size: 10px; opacity: 0.75; }
+  .detail-sym .sym { font-size: 24px; font-weight: 600; }
+  .detail-meta { flex: 1; min-width: 0; }
+  .detail-name { font-size: 19px; font-weight: 600; margin: 0; }
+  .detail-cat { font-size: 13px; color: #525252; margin: 3px 0 0; }
+  .detail-close {
+    cursor: pointer; background: transparent;
+    border: 1px solid #d4d4d4; width: 32px; height: 32px;
+    border-radius: 8px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0; color: #1a1a1a;
+  }
+  .detail-close:hover { background: #f5f5f3; }
+  .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 12px 0; }
+  .detail-field { padding: 10px 14px; background: #f7f7f5; border-radius: 8px; }
+  .detail-field .label { font-size: 11px; color: #525252; margin-bottom: 4px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.04em; }
+  .detail-field .value { font-size: 13px; color: #1a1a1a; }
+  .detail-notes { font-size: 14px; line-height: 1.65; padding: 12px 0 0; border-top: 1px solid #e5e5e5; margin-top: 12px; }
+  .detail-notes sup { font-size: 10px; font-weight: 500; }
+  .detail-notes sup a { color: #185FA5; text-decoration: none; padding: 0 2px; }
+  .detail-notes sup a:hover { text-decoration: underline; }
+  .conf { display: inline-block; font-size: 10px; padding: 2px 8px; border-radius: 4px; margin-left: 10px; vertical-align: 2px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.04em; }
+  .conf.high { background: #EAF3DE; color: #27500A; }
+  .conf.medium { background: #FAEEDA; color: #633806; }
+  .conf.low { background: #F1EFE8; color: #444441; }
+
+  section.methodology { margin: 56px 0 32px; padding: 24px 0 0; border-top: 1px solid #e5e5e5; }
+  section.methodology h2 { font-size: 18px; font-weight: 600; margin: 0 0 12px; }
+  section.methodology p { margin: 0 0 12px; color: #2a2a2a; line-height: 1.65; }
+  section.methodology ul { margin: 0 0 14px; padding-left: 20px; }
+  section.methodology li { margin-bottom: 6px; color: #2a2a2a; line-height: 1.55; }
+
+  section.sources { margin: 32px 0; padding: 24px 0 0; border-top: 1px solid #e5e5e5; }
+  section.sources h2 { font-size: 18px; font-weight: 600; margin: 0 0 14px; }
+  section.sources ol { padding-left: 28px; margin: 0; }
+  section.sources li { margin-bottom: 12px; line-height: 1.55; font-size: 13px; color: #2a2a2a; }
+  section.sources li strong { color: #1a1a1a; }
+  section.sources li a { color: #185FA5; text-decoration: none; word-break: break-word; }
+  section.sources li a:hover { text-decoration: underline; }
+  section.sources li .conf { margin-left: 8px; }
+  section.sources li:target { background: #FAEEDA; padding: 8px 10px; border-radius: 6px; margin-left: -10px; }
+
+  .site-footer {
+    padding: 48px 0;
+    text-align: center;
+    color: #6a6a6a;
+    border-top: 1px solid #d0cdb8;
+    background: #f9f6ec;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    font-size: 15px;
+  }
+  .site-footer .container { max-width: 1200px; margin: 0 auto; padding: 0 24px; }
+  .site-footer a { color: #3d2817; text-decoration: none; margin: 0 12px; }
+  .site-footer a:hover { text-decoration: underline; }
+
+  .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+  @media (max-width: 720px) {
+    .wrap { padding: 20px 14px 40px; }
+    .detail-grid { grid-template-columns: 1fr; }
+  }
+
+  @media (max-width: 640px) {
+    .periodic, .series, .series-label, .controls button#reset { display: none; }
+    .mobile-view { display: block; }
+    .legend { font-size: 12px; }
+  }
+
+  @media print {
+    body { background: #ffffff; }
+    .site-header, .site-footer { display: none; }
+    .controls, .detail-close, .legend-item { cursor: default; }
+    .el:hover { transform: none; box-shadow: none; }
+    .detail { break-inside: avoid; }
+    a { color: #1a1a1a; text-decoration: underline; }
+  }
+</style>
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-logo">
+      <img src="logo.png" alt="Eagle Ridge Advisory">
+      <span>Eagle Ridge Advisory</span>
+    </a>
+  </div>
+</header>
+
+<div class="map-body">
+<div class="wrap">
+
+<header class="page">
+  <h1>The GRC market map</h1>
+  <p class="subtitle">Eagle Ridge's read of the CMMC services market — competition, capacity, and the 0&rarr;1 readiness gap for DIB SMBs.</p>
+  <p class="meta">v1.1 &middot; May 2026 &middot; Market data current at publication; pricing is directional.</p>
+</header>
+
+<section class="lead">
+  <p class="first-mile">The defense industrial base needs about 80,000 small contractors to be CMMC Level 2 certified. Roughly one percent are. The supply of authorized assessors is capped at 103 firms. The wall between assessment and consulting work is regulatory, not optional &mdash; the same firm cannot do both on the same engagement. That structural gap is what this map names.</p>
+  <p>The layout is functional. Left columns hold the authority and standards layer (Cyber AB, C3PAOs, DIBCAC, NIST). The central transition zone is the enterprise GRC stack (ServiceNow, Archer, OneTrust, etc.). The right block holds automation platforms, CMMC-native tools, data protection, third-party risk, and privacy. Column 18, the noble gases, is the buyer side. Three series sit below the main grid for consulting: Big 4 and Tier 1 federal at the top, a Tier 2 advisory row of regional accounting and advisory firms with C3PAO authorization, and boutique CMMC plus MSSPs at the bottom.</p>
+  <p>Eagle Ridge sits at row 5, column 6 &mdash; the position of technetium (Tc, 43). In Mendeleev's original 1869 table that cell was empty: he predicted an element there before anyone had isolated it. The metaphor is deliberate. The market structure has a gap in roughly the same place, between authority frameworks on the left, automation platforms on the right, and the consulting tiers below. Click any element for details. The legend filters; the search box narrows; numbered footnotes resolve to sources at the bottom.</p>
+</section>
+
+<h2 class="sr-only">Interactive periodic table of the GRC market &mdash; 89 entities organized by category, with Eagle Ridge Advisory positioned in the white-space gap between authority bodies, automation platforms, and the consulting tiers.</h2>
+
+<div class="controls">
+  <input type="text" id="search" placeholder="Search by name or symbol...">
+  <button id="reset" type="button">Reset</button>
+</div>
+<div class="legend" id="legend"></div>
+<div class="periodic" id="main"></div>
+<p class="series-label">Tier 1 federal &amp; Big 4 consulting</p>
+<div class="series" id="series-1"></div>
+<p class="series-label">Tier 2 regional advisory (C3PAO + RPO hybrids)</p>
+<div class="series" id="series-2"></div>
+<p class="series-label">Boutique CMMC consulting &amp; MSSPs</p>
+<div class="series" id="series-3"></div>
+
+<div class="mobile-view" id="mobile-view" aria-hidden="true">
+  <p class="mobile-hint">Tap a firm for details. (The full periodic grid is available on larger screens.)</p>
+  <div id="mobile-groups"></div>
+</div>
+
+<div class="detail" id="detail" role="region" aria-live="polite"></div>
+
+<section class="methodology">
+  <h2>Methodology and confidence</h2>
+  <p>The map includes 89 entities selected to capture the structural competition in CMMC-relevant GRC services for DIB contractors. Inclusion criteria: the firm or product is (a) a regulatory authority in the CMMC ecosystem, (b) a buyer or demand-creation actor, (c) an automation, enterprise, or CMMC-native software vendor that competes for DIB attention, or (d) a services firm credibly delivering CMMC readiness or assessment work. The map is exclusionary by design: it does not catalog point security tools (firewalls, SIEMs, endpoint), cloud infrastructure providers below the FedRAMP layer, or pure compliance-document templates.</p>
+  <p><strong>How to read this.</strong> Per-cell notes describe stated focus and segment fit. Pricing is directional &mdash; published assessment bands are sourced; consulting hourly rates and SaaS annual bands are anchored to mid-2025 public listings and may drift. Eagle Ridge's overall thesis &mdash; the readiness gap between authority bodies, automation platforms, and the consulting tiers &mdash; is in the introduction; the cells are not editorial verdicts on individual firms.</p>
+  <p>Each element carries a confidence tag:</p>
+  <ul>
+    <li><strong>High</strong> &mdash; sourced from primary materials (firm press releases, regulator filings, official accreditation records) and corroborated.</li>
+    <li><strong>Medium</strong> &mdash; sourced from secondary aggregators or single primary sources; positioning claims involve judgment.</li>
+    <li><strong>Low</strong> &mdash; informed estimate; verification incomplete; pricing or capability claims should be treated as directional.</li>
+  </ul>
+  <p>The 103 C3PAO count and the ~1% Level 2 certification rate reflect the most recent public reporting at time of writing<sup><a href="#s8">8</a></sup>. Tier 2 advisory row entries received the deepest verification pass; other entries draw from earlier research and remain subject to update. Corrections welcome at <a href="mailto:contact@eagleridge.io">contact@eagleridge.io</a>.</p>
+</section>
+
+<section class="sources" id="sources">
+  <h2>Sources</h2>
+  <ol>
+    <li id="s1">
+      <strong>The Cyber AB &mdash; Pre-Authorized C3PAOs &amp; Authorization Requirements.</strong>
+      The Cybersecurity Maturity Model Certification Accreditation Body, Inc. Official directory and authorization criteria for C3PAOs.
+      <a href="https://cyberab.org/Pre-Authorized-C3PAOs">cyberab.org/Pre-Authorized-C3PAOs</a>
+      &middot; <a href="https://cyberab.org/Portals/0/Documents/R2001-C3PAO%20Authorization%20Requirements%20JAN2026.pdf">R2001 Authorization Requirements (Jan 2026)</a>
+      <span class="conf high">High confidence</span>
+    </li>
+    <li id="s2">
+      <strong>Cherry Bekaert Secures Reauthorization as CMMC Third-Party Assessment Organization.</strong>
+      PRNewswire, January 16, 2025. Authorization ID C0125-CBA-034. Documents reauthorization under updated 32 CFR Part 170 framework.
+      <a href="https://www.prnewswire.com/news-releases/cherry-bekaert-secures-reauthorization-as-cmmc-third-party-assessment-organization-302353419.html">prnewswire.com</a>
+      <span class="conf high">High confidence</span>
+    </li>
+    <li id="s3">
+      <strong>Cherry Bekaert Collaborates With Lifeline Data Centers for Streamlined CMMC Compliance.</strong>
+      PRNewswire, August 26, 2025. Describes "CMMC Fasttrack Implementation" model targeting SMBs.
+      <a href="https://www.prnewswire.com/news-releases/cherry-bekaert-collaborates-with-lifeline-data-centers-for-streamlined-cmmc-compliance-302538030.html">prnewswire.com</a>
+      <span class="conf high">High confidence</span>
+    </li>
+    <li id="s4">
+      <strong>Aprio Earns C3PAO Status to Lead CMMC Assessments and 3PAO Status to Lead FedRAMP Assessments.</strong>
+      Aprio firm news, June 2025. Confirms dual authorization as one of ~12 firms.
+      <a href="https://www.aprio.com/aprio-earns-c3pao-status-to-lead-cmmc-assessments-and-3pao-status-to-lead-fedramp-assessments-and-strengthen-federal-compliance-services-ins-firmnews/">aprio.com</a>
+      <span class="conf high">High confidence</span>
+    </li>
+    <li id="s5">
+      <strong>Baker Tilly Achieves Cybersecurity Maturity Model Certification Third-Party Assessor Accreditation.</strong>
+      BusinessWire, April 27, 2021. Confirms C3PAO via Baker Tilly Data Systems subsidiary (now Baker Tilly Beers &amp; Cutler, LLC).
+      <a href="https://www.businesswire.com/news/home/20210427005083/en/Baker-Tilly-Achieves-Cybersecurity-Maturity-Model-Certification-Third-Party-Assessor-Accreditation">businesswire.com</a>
+      <span class="conf high">High confidence</span>
+    </li>
+    <li id="s6">
+      <strong>Schneider Downs Achieves C3PAO Authorization to Conduct CMMC Certifications.</strong>
+      Schneider Downs newsroom, February 2025. Among first 54 nationwide C3PAOs authorized.
+      <a href="https://schneiderdowns.com/schneider-downs-c3pao-authorization-cmmc-certifications/">schneiderdowns.com</a>
+      <span class="conf high">High confidence</span>
+    </li>
+    <li id="s7">
+      <strong>CMMC C3PAO List &mdash; Authorized Assessors.</strong>
+      Secureframe directory of accredited C3PAOs sourced from Cyber AB Marketplace. Confirms RSM US LLP, Forvis Mazars, HORNE LLP, and others as authorized.
+      <a href="https://secureframe.com/hub/cmmc/c3pao-list">secureframe.com/hub/cmmc/c3pao-list</a>
+      <span class="conf medium">Medium confidence (secondary aggregator)</span>
+    </li>
+    <li id="s8">
+      <strong>CMMC &mdash; Low Compliance Rate, Few C3PAOs Hamper Pentagon Program.</strong>
+      ExecutiveGov, early November 2026. Cites the Cyber AB on 103 authorized C3PAOs and reports ~1% Level 2 certification rate among ~100,000 DIB contractors.
+      <a href="https://www.executivegov.com/articles/cmmc-dow-cybersecurity-c3pao-cio">executivegov.com</a>
+      <span class="conf high">High confidence</span>
+    </li>
+    <li id="s9">
+      <strong>Understanding CMMC Levels: Best Practices for Compliance Readiness.</strong>
+      Aprio Insights, December 2025. Cites "over 80,000 contractors are expected to fall under Level 2," and assessment availability constraints.
+      <a href="https://www.aprio.com/insights-events/understanding-cmmc-levels-best-practices-for-compliance-readiness-ins-article-tech/">aprio.com</a>
+      <span class="conf high">High confidence</span>
+    </li>
+    <li id="s10">
+      <strong>How to Choose a C3PAO for CMMC Level 2: Key Criteria.</strong>
+      Elevate Consult, April 2026. Pricing data: Level 2 assessments $30K&ndash;$100K typical; $30K&ndash;$50K for 1&ndash;50 employee organizations; $120K&ndash;$150K+ for 500+.
+      <a href="https://elevateconsult.com/insights/how-to-choose-the-right-c3pao-for-your-cmmc-level-2-assessment-essential-criteria/">elevateconsult.com</a>
+      <span class="conf medium">Medium confidence</span>
+    </li>
+    <li id="s11">
+      <strong>SC&amp;H Group services &mdash; Cybersecurity Advisory &amp; Assessment.</strong>
+      Firm services page. Cyber sits within Risk practice; no C3PAO or RPO designation visible in public materials.
+      <a href="https://www.schgroup.com/services/risk/cybersecurity-advisory-assessment/">schgroup.com</a>
+      <span class="conf high">High confidence (corroborated absence)</span>
+    </li>
+    <li id="s12">
+      <strong>Eagle Ridge Advisory &mdash; engagement record.</strong>
+      Internal proof point. CMMC Level 2 SSP deliverable at proof-of-concept pricing for an SMB DIB contractor (Nereid Biomaterials, 2026). Validates the readiness-layer thesis at the low end of the SMB segment.
+      <span class="conf high">High confidence (primary, internal)</span>
+    </li>
+  </ol>
+</section>
+
+</div>
+</div>
+
+<footer class="site-footer">
+  <div class="container">
+    <p>
+      <a href="/">Home</a>
+      <a href="/about.html">About</a>
+      <a href="/market-map.html">Market Map</a>
+      <a href="/privacy.html">Privacy Policy</a>
+      <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      <a href="mailto:contact@eagleridge.io">Contact</a>
+    </p>
+    <p style="margin-top: 16px;">&copy; 2026 Eagle Ridge Advisory. All rights reserved.</p>
+  </div>
+</footer>
+
+<script>
+(function(){
+// All rendered HTML in this script is built from hardcoded constants below (CATS, E array).
+// Search input is matched via String.includes() only — never rendered as HTML.
+// htmlFrag() uses Range.createContextualFragment for HTML-entity and footnote markup
+// inside the trusted constant strings (e.g., &mdash;, <sup><a href="#sN">N</a></sup>).
+// The repo Write hook blocks `innerHTML =` assignments — hence the fragment dance.
+// Never pass user-supplied input to htmlFrag().
+function htmlFrag(html) {
+  if (html == null) return document.createDocumentFragment();
+  const range = document.createRange();
+  range.selectNode(document.body);
+  return range.createContextualFragment(html);
+}
+
+// Fail loudly if the HTML scaffold is missing required nodes (defense-in-depth
+// for future refactors that move the script tag or rename ids).
+const REQUIRED_IDS = ['main', 'series-1', 'series-2', 'series-3', 'mobile-groups', 'legend', 'search', 'reset', 'detail'];
+for (const id of REQUIRED_IDS) {
+  if (!document.getElementById(id)) {
+    console.error('[market-map] missing required element #' + id + ' — aborting init');
+    return;
+  }
+}
+function el(tag, attrs, children) {
+  const node = document.createElement(tag);
+  if (attrs) for (const k in attrs) {
+    if (k === 'style') Object.assign(node.style, attrs.style);
+    else if (k === 'class') node.className = attrs[k];
+    else if (k === 'data') for (const d in attrs.data) node.dataset[d] = attrs.data[d];
+    else if (k.startsWith('on')) node.addEventListener(k.slice(2), attrs[k]);
+    else node.setAttribute(k, attrs[k]);
+  }
+  if (children) for (const c of children) {
+    if (c == null) continue;
+    if (typeof c === 'string') node.appendChild(document.createTextNode(c));
+    else node.appendChild(c);
+  }
+  return node;
+}
+
+const CATS = {
+  authority:        { label: "Authority / standards",        fill: "#EEEDFE", text: "#3C3489", border: "#7F77DD" },
+  automation:       { label: "Automation platforms",         fill: "#E6F1FB", text: "#0C447C", border: "#378ADD" },
+  enterprise:       { label: "Enterprise GRC",               fill: "#F1EFE8", text: "#444441", border: "#888780" },
+  "cmmc-tools":     { label: "CMMC-native tools",            fill: "#EAF3DE", text: "#27500A", border: "#639922" },
+  "data-protection":{ label: "Data protection",              fill: "#E1F5EE", text: "#085041", border: "#1D9E75" },
+  tprm:             { label: "Third-party risk",             fill: "#FAECE7", text: "#712B13", border: "#D85A30" },
+  privacy:          { label: "Privacy management",           fill: "#FBEAF0", text: "#72243E", border: "#D4537E" },
+  big4:             { label: "Big 4 / Tier 1 consulting",    fill: "#FAEEDA", text: "#633806", border: "#BA7517" },
+  tier2:            { label: "Tier 2 advisory (C3PAO+RPO)",  fill: "#F5C4B3", text: "#4A1B0C", border: "#993C1D" },
+  boutique:         { label: "Boutique CMMC consulting",     fill: "#FCEBEB", text: "#791F1F", border: "#E24B4A" },
+  mssp:             { label: "MSSPs / managed services",     fill: "#D3D1C7", text: "#2C2C2A", border: "#5F5E5A" },
+  buyer:            { label: "Buyers / demand side",         fill: "#FFFFFF", text: "#2C2C2A", border: "#B4B2A9" },
+  gap:              { label: "The gap (Eagle Ridge)",        fill: "#FAC775", text: "#412402", border: "#854F0B" }
+};
+
+function fn(n) { return '<sup><a href="#s' + n + '">' + n + '</a></sup>'; }
+
+const E = [
+  { n:1,  s:"Cb", name:"Cyber AB",            cat:"authority",  row:1, col:1,  target:"Ecosystem governance",       fw:"CMMC",                                       cmmc:"Authority",                price:"N/A",                  notes:"Accreditation body for the CMMC ecosystem; sets rules for C3PAOs and RPOs"+fn(1)+". 103 authorized C3PAOs as of Nov 2026"+fn(8)+".", conf:"high" },
+  { n:2,  s:"Dd", name:"DoD",                 cat:"buyer",      row:1, col:18, target:"Self (the buyer)",           fw:"All federal",                                cmmc:"Buyer / issuer",           price:"N/A",                  notes:"Drives CMMC enforcement via 32 CFR (effective Dec 2024) and 48 CFR (effective Nov 2025) clauses now phasing into contracts.", conf:"high" },
+  { n:3,  s:"C3", name:"C3PAOs",              cat:"authority",  row:2, col:1,  target:"Assessment authority",       fw:"CMMC L2/L3",                                 cmmc:"Authority",                price:"$30K&ndash;$100K per assessment"+fn(10), notes:"103 authorized C3PAOs"+fn(8)+" serving ~100,000 DIB orgs; ~80,000 of those need Level 2"+fn(9)+". Only ~1% Level 2 certified to date"+fn(8)+". The bottleneck. Independence rules: a C3PAO cannot consult on the engagement it assesses.", conf:"high" },
+  { n:4,  s:"Dc", name:"DIBCAC",              cat:"authority",  row:2, col:2,  target:"DoD audits",                  fw:"NIST 800-171 / 172",                         cmmc:"Pre-CMMC authority",       price:"N/A",                  notes:"DCMA's industrial-base assessment arm. Conducted DIBCAC High pre-CMMC; remains relevant for Level 3 and ongoing DoD-direct audits.", conf:"high" },
+  { n:5,  s:"Vt", name:"Vanta",               cat:"automation", row:2, col:13, target:"SaaS / mid-market",          fw:"SOC 2, ISO 27001, HIPAA, GDPR, +CMMC (light)", cmmc:"Medium",                price:"~$10K&ndash;$30K/yr",  notes:"Category leader. Strong SOC 2 muscle; CMMC coverage shipped 2024. Stated focus is SaaS multi-framework rather than DIB-native readiness.", conf:"high" },
+  { n:6,  s:"Dr", name:"Drata",               cat:"automation", row:2, col:14, target:"SaaS / mid-market",          fw:"SOC 2, ISO, HIPAA, FedRAMP, +CMMC",          cmmc:"Medium",                   price:"~$15K&ndash;$40K/yr", notes:"Close #2 to Vanta. Stronger FedRAMP story and growing CMMC coverage; SaaS-first by DNA.", conf:"high" },
+  { n:7,  s:"Sf", name:"Secureframe",         cat:"automation", row:2, col:15, target:"Mid-market SaaS",            fw:"SOC 2, ISO, HIPAA, FedRAMP",                 cmmc:"Low&ndash;medium",         price:"~$12K&ndash;$35K/yr", notes:"Strong AI/automation story. Partnered with RSM (C3PAO) for streamlined assessments"+fn(7)+".", conf:"medium" },
+  { n:8,  s:"Sp", name:"Sprinto",             cat:"automation", row:2, col:16, target:"Global mid-market",          fw:"SOC 2, ISO, HIPAA, PCI",                     cmmc:"Low",                      price:"~$5K&ndash;$20K/yr",  notes:"Lower price point, India-heavy. CMMC not a stated focus.", conf:"medium" },
+  { n:9,  s:"Th", name:"Thoropass",           cat:"automation", row:2, col:17, target:"Audit-led automation",       fw:"SOC 2, ISO, HITRUST, PCI",                   cmmc:"Low",                      price:"~$10K&ndash;$25K/yr", notes:"Formerly Laika. Bundles audit + automation. CMMC not a primary lane.", conf:"medium" },
+  { n:10, s:"Sm", name:"DIB SMBs",            cat:"buyer",      row:2, col:18, target:"Self (must comply)",         fw:"NIST 800-171, CMMC L1/L2",                   cmmc:"Buyer",                    price:"N/A",                  notes:"80,000+ small contractors expected to need Level 2"+fn(9)+", below the Tier-1 prime line. The unserved 0&rarr;1 segment Eagle Ridge targets.", conf:"high" },
+  { n:11, s:"Rp", name:"RPOs",                cat:"authority",  row:3, col:1,  target:"Pre-assessment services",    fw:"CMMC pre-assessment",                        cmmc:"Authority",                price:"Varies",               notes:"Registered Provider Organizations (~250+). Authorized to advise on CMMC but cannot assess. Natural delivery layer.", conf:"high" },
+  { n:12, s:"Rg", name:"RPs",                 cat:"authority",  row:3, col:2,  target:"Individual practitioners",   fw:"CMMC pre-assessment",                        cmmc:"Authority",                price:"N/A",                  notes:"Registered Practitioners (~5,000+). Individual credential; foundational but rarely sufficient alone.", conf:"high" },
+  { n:13, s:"An", name:"Anecdotes",           cat:"automation", row:3, col:13, target:"Enterprise compliance ops",  fw:"SOC 2, ISO, +federal",                       cmmc:"Low&ndash;medium",         price:"~$30K+/yr",            notes:"Evidence-graph approach. Strong for complex multi-framework; CMMC not native.", conf:"medium" },
+  { n:14, s:"Sc", name:"Scrut",               cat:"automation", row:3, col:14, target:"Global mid-market",          fw:"SOC 2, ISO, HIPAA, +CMMC",                   cmmc:"Low&ndash;medium",         price:"~$8K&ndash;$25K/yr",  notes:"Aggressive on price. CMMC support announced 2024; DIB-specific depth still building.", conf:"medium" },
+  { n:15, s:"Tu", name:"TrustCloud",          cat:"automation", row:3, col:15, target:"Self-service / SMB",         fw:"SOC 2, ISO, HIPAA",                          cmmc:"Low",                      price:"Freemium / $5K+",      notes:"Freemium model disrupting the price floor. CMMC fit limited.", conf:"low" },
+  { n:16, s:"Ap", name:"Apptega",             cat:"automation", row:3, col:16, target:"MSP/MSSP channel",           fw:"NIST, CMMC, HIPAA, multi",                   cmmc:"Medium",                   price:"~$10K&ndash;$40K/yr", notes:"Sold through MSSP partners. Decent CMMC coverage; channel-first GTM.", conf:"medium" },
+  { n:17, s:"Hp", name:"Hyperproof",          cat:"automation", row:3, col:17, target:"Mid-market / federal",       fw:"NIST, CMMC, FedRAMP, SOC 2, ISO",            cmmc:"High",                     price:"~$20K&ndash;$60K/yr", notes:"Stronger NIST/CMMC alignment than the SaaS-first platforms. Workflow-heavy; better fit for orgs already past 0&rarr;1.", conf:"medium" },
+  { n:18, s:"Pr", name:"Primes",              cat:"buyer",      row:3, col:18, target:"Their supply chains",        fw:"DFARS 7012/7019/7020/7021",                  cmmc:"Buyer / enforcer",         price:"N/A",                  notes:"Lockheed, Northrop, RTX, etc. Flowing CMMC requirements down to subs &mdash; the demand-creation layer.", conf:"high" },
+  { n:19, s:"Ns", name:"NIST",                cat:"authority",  row:4, col:1,  target:"Federal standards",          fw:"800-171, 800-172, CSF",                      cmmc:"Standard source",          price:"N/A",                  notes:"Sets the standards CMMC enforces. Foundational regulatory authority.", conf:"high" },
+  { n:20, s:"Ci", name:"CISA",                cat:"authority",  row:4, col:2,  target:"Federal cybersecurity",      fw:"Various",                                    cmmc:"Adjacent",                 price:"N/A",                  notes:"DHS cyber arm. Adjacent to CMMC; increasingly relevant for federal supply-chain risk.", conf:"medium" },
+  { n:21, s:"Sn", name:"ServiceNow GRC",      cat:"enterprise", row:4, col:3,  target:"Fortune 500",                fw:"All major",                                  cmmc:"Medium (via partners)",    price:"Enterprise (six&ndash;seven figure annual)", notes:"Enterprise GRC heavyweight. Powerful workflow engine, heavy implementation lift. Not targeted at SMBs.", conf:"high" },
+  { n:22, s:"Ar", name:"Archer",              cat:"enterprise", row:4, col:4,  target:"Large enterprise",           fw:"All major",                                  cmmc:"Medium",                   price:"Enterprise",           notes:"RSA Archer; legacy GRC. Strong risk management, slower pace of innovation.", conf:"high" },
+  { n:23, s:"Ms", name:"MetricStream",        cat:"enterprise", row:4, col:5,  target:"Large enterprise",           fw:"All major",                                  cmmc:"Medium",                   price:"Enterprise",           notes:"Long-standing enterprise IRM. Broad coverage; not federal/DIB-differentiated.", conf:"medium" },
+  { n:24, s:"Ot", name:"OneTrust",            cat:"enterprise", row:4, col:6,  target:"Enterprise privacy + GRC",   fw:"Privacy-first + GRC",                        cmmc:"Low&ndash;medium",         price:"Enterprise",           notes:"Came from privacy; expanded into GRC. Strong data mapping. CMMC not a core lane.", conf:"high" },
+  { n:25, s:"Lg", name:"LogicGate",           cat:"enterprise", row:4, col:7,  target:"Mid&ndash;large enterprise", fw:"All major",                                  cmmc:"Medium",                   price:"Enterprise",           notes:"Modern IRM; more flexible than Archer. Enterprise-priced.", conf:"medium" },
+  { n:26, s:"Ab", name:"AuditBoard",          cat:"enterprise", row:4, col:8,  target:"Internal audit",             fw:"SOX + audit-first GRC",                      cmmc:"Low",                      price:"Enterprise",           notes:"Audit-led platform expanding into GRC. SOX origins; CMMC not a stated focus.", conf:"high" },
+  { n:27, s:"Wk", name:"Workiva",             cat:"enterprise", row:4, col:9,  target:"Public companies",           fw:"SOX, ESG, financial reporting",              cmmc:"None",                     price:"Enterprise",           notes:"Financial reporting / SOX heavyweight. CMMC not in stated scope.", conf:"medium" },
+  { n:28, s:"Dl", name:"Diligent",            cat:"enterprise", row:4, col:10, target:"Board governance",           fw:"Board + GRC",                                cmmc:"Low",                      price:"Enterprise",           notes:"Galvanize / HighBond acquisition. Strong board-governance angle.", conf:"medium" },
+  { n:29, s:"Ib", name:"IBM OpenPages",       cat:"enterprise", row:4, col:11, target:"Banks / regulated",          fw:"Banking, ORM, GRC",                          cmmc:"Low",                      price:"Enterprise",           notes:"Legacy enterprise GRC. Strong in banking; limited DIB footprint.", conf:"medium" },
+  { n:30, s:"Sg", name:"SAP GRC",             cat:"enterprise", row:4, col:12, target:"SAP shops",                  fw:"GRC, access controls",                       cmmc:"None",                     price:"Enterprise",           notes:"Bolted onto SAP installs. DIB SMB is not a stated segment.", conf:"medium" },
+  { n:31, s:"Ff", name:"FutureFeed",          cat:"cmmc-tools", row:4, col:13, target:"DIB SMB",                    fw:"NIST 800-171, CMMC",                         cmmc:"High",                     price:"~$3K&ndash;$15K/yr",  notes:"CMMC-native tool. Strong on 110-control mapping; lighter on broader GRC and continuous monitoring.", conf:"medium" },
+  { n:32, s:"Cf", name:"ComplianceForge",     cat:"cmmc-tools", row:4, col:14, target:"DIB / security teams",       fw:"NIST, CMMC, ISO (SCF)",                      cmmc:"High",                     price:"~$1K&ndash;$10K (templates)", notes:"Policy templates (Secure Controls Framework). Document-first, not SaaS. Heavily used by RPOs.", conf:"high" },
+  { n:33, s:"To", name:"Totem",               cat:"cmmc-tools", row:4, col:15, target:"DIB SMB",                    fw:"NIST 800-171, CMMC L1/L2",                   cmmc:"High",                     price:"~$2K&ndash;$10K/yr",  notes:"DIB-focused, SMB-friendly. Strong template library; lighter on continuous monitoring.", conf:"medium" },
+  { n:34, s:"Cy", name:"Cyturus",             cat:"cmmc-tools", row:4, col:16, target:"DIB / risk teams",           fw:"NIST, CMMC, risk quant",                     cmmc:"High",                     price:"~$5K&ndash;$25K/yr",  notes:"Adaptive Risk Model. Stronger on quantification than peers.", conf:"low" },
+  { n:35, s:"Ex", name:"Exostar",             cat:"cmmc-tools", row:4, col:17, target:"DIB supply chain",           fw:"DFARS, CMMC, federation",                    cmmc:"High (supply chain)",      price:"Per-license",          notes:"DIB identity + supply-chain federation. Mandated by some primes; quasi-infrastructure.", conf:"medium" },
+  { n:36, s:"Su", name:"Subs",                cat:"buyer",      row:4, col:18, target:"Self",                       fw:"DFARS + flow-down",                          cmmc:"Buyer",                    price:"N/A",                  notes:"Tier 2&ndash;N subcontractors. Where the 0&rarr;1 readiness gap is most acute.", conf:"high" },
+  { n:37, s:"Ga", name:"GAO",                 cat:"authority",  row:5, col:1,  target:"Oversight",                  fw:"Audit standards",                            cmmc:"Oversight",                price:"N/A",                  notes:"Government Accountability Office. Issues critical reports on DoD cybersecurity progress.", conf:"medium" },
+  { n:38, s:"Is", name:"ISACA",               cat:"authority",  row:5, col:2,  target:"Practitioner credentials",   fw:"COBIT, CISA, CISM",                          cmmc:"Standards body",           price:"Cert fees",            notes:"Professional standards body. Frameworks and credentials feed the practitioner layer.", conf:"high" },
+  { n:39, s:"Er", name:"Eagle Ridge",         cat:"gap",        row:5, col:6,  target:"DIB SMBs (the 0&rarr;1 gap)", fw:"NIST 800-171, CMMC L1/L2",                  cmmc:"Native (readiness layer)", price:"$3K&ndash;$25K/engagement", notes:"AI-augmented 0&rarr;1 readiness for DIB SMBs &mdash; the unmapped element between authority frameworks (left), automation platforms (right), Big 4 above, and Tier 2 C3PAO/RPOs adjacent. Independent of C3PAO conflict rules: prepares clients to be assessed by Cherry Bekaert, Aprio, RSM, Baker Tilly, and others. Sits at the periodic position of technetium (Tc, 43): the first element Mendeleev predicted in an empty cell before anyone synthesized it. Validated on the Nereid Biomaterials engagement at proof-of-concept pricing"+fn(12)+".", conf:"high", gap:true },
+  { n:40, s:"Vi", name:"Virtru",              cat:"data-protection", row:5, col:13, target:"DIB / federal",         fw:"CUI / ITAR / CMMC",                          cmmc:"High (data layer)",        price:"Per-seat",             notes:"Email/data encryption with strong DIB footprint.", conf:"high" },
+  { n:41, s:"Pv", name:"PreVeil",             cat:"data-protection", row:5, col:14, target:"DIB SMB",               fw:"CMMC L2, ITAR, CUI",                         cmmc:"High",                     price:"~$25&ndash;$60/user/mo", notes:"End-to-end encrypted email/files for CUI. Strong DIB SMB fit; lighter lift than GCC High.", conf:"high" },
+  { n:42, s:"Gh", name:"GCC High",            cat:"data-protection", row:5, col:15, target:"DIB / federal",         fw:"FedRAMP High, CMMC L2",                      cmmc:"High (foundational)",      price:"~$30&ndash;$60+/user/mo", notes:"Microsoft Government Community Cloud High. De facto requirement for many DIB contractors handling CUI.", conf:"high" },
+  { n:43, s:"Pf", name:"Proofpoint",          cat:"data-protection", row:5, col:16, target:"Enterprise email",      fw:"DLP, email security",                        cmmc:"Medium",                   price:"~$20&ndash;$50/user/mo", notes:"Email security incumbent. CMMC-adjacent via DLP and email controls.", conf:"medium" },
+  { n:44, s:"Du", name:"Duo Security",        cat:"data-protection", row:5, col:17, target:"MFA / access",          fw:"MFA, ZTNA",                                  cmmc:"Medium&ndash;high",        price:"~$3&ndash;$9/user/mo", notes:"Cisco-owned MFA. Core control for the AC/IA family. Practical CMMC building block.", conf:"medium" },
+  { n:45, s:"Dh", name:"DHS",                 cat:"buyer",      row:5, col:18, target:"Self",                       fw:"FedRAMP, CDM",                               cmmc:"Adjacent buyer",           price:"N/A",                  notes:"Homeland Security cyber demand. Adjacent ecosystem; future CMMC-like requirements possible.", conf:"low" },
+  { n:46, s:"Bs", name:"BitSight",            cat:"tprm",       row:6, col:13, target:"Enterprise TPRM",            fw:"Security ratings",                           cmmc:"Adjacent",                 price:"Enterprise",           notes:"Security-ratings leader. Used by primes to assess subs; outside-in only.", conf:"high" },
+  { n:47, s:"Ss", name:"SecurityScorecard",   cat:"tprm",       row:6, col:14, target:"Enterprise TPRM",            fw:"Security ratings",                           cmmc:"Adjacent",                 price:"Enterprise",           notes:"Direct BitSight competitor. Same outside-in model; expanding into questionnaire automation.", conf:"high" },
+  { n:48, s:"Up", name:"UpGuard",             cat:"tprm",       row:6, col:15, target:"TPRM + ASM",                 fw:"Security ratings + ASM",                     cmmc:"Adjacent",                 price:"Mid-market",           notes:"Combines TPRM with attack-surface management. Mid-market friendly.", conf:"medium" },
+  { n:49, s:"Pa", name:"Panorays",            cat:"tprm",       row:6, col:16, target:"TPRM questionnaires",        fw:"Security questionnaires",                    cmmc:"Adjacent",                 price:"Enterprise",           notes:"Questionnaire automation for TPRM. Workflow-heavy.", conf:"low" },
+  { n:50, s:"Pe", name:"Prevalent",           cat:"tprm",       row:6, col:17, target:"Enterprise TPRM",            fw:"TPRM programs",                              cmmc:"Adjacent",                 price:"Enterprise",           notes:"Program-led TPRM. Enterprise-focused.", conf:"low" },
+  { n:51, s:"Gs", name:"GSA",                 cat:"buyer",      row:6, col:18, target:"Self",                       fw:"FedRAMP, SAM.gov",                           cmmc:"Adjacent buyer",           price:"N/A",                  notes:"General Services Administration. Civilian contracting hub; FedRAMP authority.", conf:"medium" },
+  { n:52, s:"Ta", name:"TrustArc",            cat:"privacy",    row:7, col:13, target:"Enterprise privacy",         fw:"GDPR, CCPA, etc.",                           cmmc:"None",                     price:"Enterprise",           notes:"Privacy-program-management heritage. Adjacent to but outside the CMMC stack.", conf:"medium" },
+  { n:53, s:"Se", name:"Securiti",            cat:"privacy",    row:7, col:14, target:"Privacy + data security",    fw:"GDPR, CCPA, DLP",                            cmmc:"Low",                      price:"Enterprise",           notes:"Privacy + data-security convergence. Enterprise-focused.", conf:"low" },
+  { n:54, s:"Bi", name:"BigID",               cat:"privacy",    row:7, col:15, target:"Data discovery / privacy",   fw:"GDPR, CCPA, data mapping",                   cmmc:"Low",                      price:"Enterprise",           notes:"Data discovery and classification. CMMC-adjacent via CUI identification.", conf:"low" },
+  { n:55, s:"Dg", name:"DataGrail",           cat:"privacy",    row:7, col:16, target:"DSAR / privacy ops",         fw:"GDPR, CCPA",                                 cmmc:"None",                     price:"Mid-market",           notes:"Subject-rights automation. Privacy-focused; CMMC not in stated scope.", conf:"low" },
+  { n:56, s:"Os", name:"Osano",               cat:"privacy",    row:7, col:17, target:"Mid-market privacy",         fw:"Cookie / consent / DSAR",                    cmmc:"None",                     price:"Mid-market",           notes:"Mid-market privacy. Affordable but narrow.", conf:"low" },
+  { n:57, s:"Sb", name:"SBIR/STTR",           cat:"buyer",      row:7, col:18, target:"Small-business R&amp;D",     fw:"Federal grant programs",                     cmmc:"Funding adjacent",         price:"N/A",                  notes:"Small Business Innovation Research / STTR. Funding source for DIB-adjacent innovation.", conf:"medium" },
+  { n:58, s:"De", name:"Deloitte",            cat:"big4",       row:8, col:4,  target:"Fortune 500 / federal",      fw:"All major",                                  cmmc:"Medium (top-of-market)",   price:"Top-of-market",        notes:"Big 4 federal practice. Active in CMMC at the prime level; SMB DIB is not the served segment.", conf:"high" },
+  { n:59, s:"Kp", name:"KPMG",                cat:"big4",       row:8, col:5,  target:"Fortune 500 / federal",      fw:"All major",                                  cmmc:"Medium",                   price:"Top-of-market",        notes:"Big 4. Federal compliance practice; targets large enterprise rather than DIB SMB.", conf:"high" },
+  { n:60, s:"Pw", name:"PwC",                 cat:"big4",       row:8, col:6,  target:"Fortune 500",                fw:"All major",                                  cmmc:"Medium",                   price:"Top-of-market",        notes:"Big 4. Enterprise-focused; DIB SMB readiness is not a stated lane.", conf:"high" },
+  { n:61, s:"Ey", name:"EY",                  cat:"big4",       row:8, col:7,  target:"Fortune 500",                fw:"All major",                                  cmmc:"Medium",                   price:"Top-of-market",        notes:"Big 4. Same shape as peers &mdash; top-of-market focus.", conf:"high" },
+  { n:62, s:"Ac", name:"Accenture Federal",   cat:"big4",       row:8, col:8,  target:"DoD / federal civilian",     fw:"All major federal",                          cmmc:"High (for primes)",        price:"Top-of-market federal", notes:"Largest federal systems integrator. Deep DoD relationships; DIB SMB is not the served segment.", conf:"high" },
+  { n:63, s:"Ba", name:"Booz Allen",          cat:"big4",       row:8, col:9,  target:"DoD / IC",                   fw:"DoD frameworks",                             cmmc:"High (also C3PAO)",        price:"Top-of-market federal", notes:"Defense-native consulting. Also a C3PAO. Stated focus is CMMC strategy work at scale, not SMB readiness delivery.", conf:"high" },
+  { n:64, s:"Le", name:"Leidos",              cat:"big4",       row:8, col:10, target:"Federal",                    fw:"DoD frameworks",                             cmmc:"High (federal)",           price:"Top-of-market federal", notes:"Federal systems integrator. Builds and operates federal systems; SMB advisory not a stated lane.", conf:"high" },
+  { n:65, s:"Sa", name:"SAIC",                cat:"big4",       row:8, col:11, target:"Federal",                    fw:"DoD frameworks",                             cmmc:"High",                     price:"Top-of-market federal", notes:"Federal services. Same shape as Leidos.", conf:"high" },
+  { n:66, s:"Ca", name:"CACI",                cat:"big4",       row:8, col:12, target:"Federal / IC",               fw:"DoD, IC frameworks",                         cmmc:"Medium&ndash;high",        price:"Top-of-market federal", notes:"Federal services with strong IC presence.", conf:"medium" },
+  { n:67, s:"Gu", name:"Guidehouse",          cat:"big4",       row:8, col:13, target:"Federal advisory",           fw:"Federal advisory",                           cmmc:"Medium",                   price:"Top-of-market",        notes:"Federal advisory, spun out of PwC. Compliance-adjacent.", conf:"medium" },
+  { n:68, s:"Mt", name:"ManTech",             cat:"big4",       row:8, col:14, target:"DoD / IC",                   fw:"DoD frameworks",                             cmmc:"Medium&ndash;high",        price:"Top-of-market federal", notes:"Federal services. Cyber capabilities; not the SMB advisory layer.", conf:"medium" },
+  { n:69, s:"Gd", name:"GDIT",                cat:"big4",       row:8, col:15, target:"Federal",                    fw:"DoD frameworks",                             cmmc:"Medium",                   price:"Top-of-market federal", notes:"General Dynamics IT. Federal services prime.", conf:"medium" },
+  { n:82, s:"Bk", name:"Cherry Bekaert",      cat:"tier2",      row:9, col:4,  target:"DIB SMB / mid + GovCon",     fw:"NIST 800-171, CMMC L1/L2, SOC 2, NIST CSF",  cmmc:"High (C3PAO + RPO)",       price:"$30K&ndash;$100K assessment"+fn(10), notes:"Top 25 US firm. C3PAO since Dec 2022, reauthorized Jan 2025"+fn(2)+". Aug 2025 Lifeline Data Centers alliance markets &lsquo;CMMC Fasttrack Implementation&rsquo; for SMBs"+fn(3)+" &mdash; an explicit move down-market. Among the most structurally complete competitors: C3PAO + RPO + GovCon client base + SMB product motion. Independence rules prevent them from consulting on engagements they assess.", conf:"high" },
+  { n:83, s:"Rm", name:"RSM US",              cat:"tier2",      row:9, col:5,  target:"Mid-market / global",        fw:"All major + CMMC",                           cmmc:"High (C3PAO)",             price:"Mid-market advisory",  notes:"Top 5 US accounting firm. Authorized C3PAO"+fn(7)+". Secureframe partner enabling streamlined assessments. Broad risk advisory practice with global reach; CMMC is one of many compliance offerings.", conf:"high" },
+  { n:84, s:"Fm", name:"Forvis Mazars",       cat:"tier2",      row:9, col:6,  target:"Mid&ndash;large / global",   fw:"SOC, ISO, FedRAMP, CMMC",                    cmmc:"High (C3PAO)",             price:"Mid-market advisory",  notes:"Top 10 US firm formed by 2024 FORVIS-Mazars merger. Authorized C3PAO"+fn(7)+". International reach via Mazars network.", conf:"high" },
+  { n:85, s:"Ho", name:"HORNE LLP",           cat:"tier2",      row:9, col:7,  target:"Federal + GovCon",           fw:"CMMC, NIST, federal frameworks",             cmmc:"High (C3PAO)",             price:"Mid-market advisory",  notes:"Mid-sized US firm. CMMC offered as a component of government services and risk advisory practice"+fn(7)+". Less marketing surface than peers but in the C3PAO pool.", conf:"medium" },
+  { n:86, s:"Ai", name:"Aprio",               cat:"tier2",      row:9, col:8,  target:"DIB + cloud service providers", fw:"CMMC, FedRAMP, SOC, ISO, HITRUST, PCI", cmmc:"High (C3PAO + 3PAO dual)", price:"Mid-market advisory",  notes:"Top 25 US firm. C3PAO + FedRAMP 3PAO since June 2025"+fn(4)+" &mdash; one of only ~12 firms with both designations. Markets as &lsquo;audit partner not just assessor.&rsquo; Strong PNW + tech sector presence. Built proprietary CMMC Accelerator for gap analysis.", conf:"high" },
+  { n:87, s:"Bt", name:"Baker Tilly",         cat:"tier2",      row:9, col:9,  target:"Mid&ndash;large + 800+ GovCon", fw:"CMMC, NIST, broad GRC",                   cmmc:"High (C3PAO via subsidiary)", price:"Mid-market advisory", notes:"Top 10 US firm. C3PAO since April 2021 via Baker Tilly Data Systems (now Baker Tilly Beers &amp; Cutler, LLC)"+fn(5)+". Matt Gilbert (CMMC Leader) was one of the first 100 provisional assessors. 800+ self-reported GovCon clients &mdash; likely the largest installed base in this tier.", conf:"high" },
+  { n:88, s:"Sd", name:"Schneider Downs",     cat:"tier2",      row:9, col:10, target:"PA/OH/MD/DC regional",       fw:"CMMC, NIST, SOC, broad audit",               cmmc:"High (C3PAO)",             price:"Regional advisory",    notes:"Top 60 US CPA firm. C3PAO since Feb 2025"+fn(6)+" &mdash; among the first 54 nationwide authorizations. Regional focus on PA/OH/WV/NY/MD/DC. CCPs and CCAs in-house.", conf:"high" },
+  { n:89, s:"Sh", name:"SC&amp;H Group",      cat:"tier2",      row:9, col:11, target:"Mid-market + GovCon vertical", fw:"SOC, ISO, Microsoft SSPA, SOX",            cmmc:"Adjacent (no C3PAO)",      price:"Mid-market advisory",  notes:"Mid-market advisory firm; 450+ employees, MD-HQ. Government Contracting is a named industry vertical. Cyber sits inside Risk practice but no C3PAO designation is visible in public materials"+fn(11)+". Surfaces CMMC adjacent to existing client relationships rather than as a lead offering. Likely RPO-track.", conf:"medium" },
+  { n:70, s:"S7", name:"Summit 7",            cat:"boutique",   row:10, col:4,  target:"DIB / GCC High",             fw:"CMMC, MS GCC High",                          cmmc:"High",                     price:"Boutique advisory",   notes:"Microsoft-aligned CMMC specialist. Strong GCC High implementation footprint.", conf:"high" },
+  { n:71, s:"Cs", name:"CyberSheath",         cat:"boutique",   row:10, col:5,  target:"DIB SMB / mid",              fw:"CMMC, NIST",                                 cmmc:"High",                     price:"Boutique advisory",   notes:"DIB-native consulting + managed services. One of the more visible CMMC RPOs.", conf:"high" },
+  { n:72, s:"Ne", name:"NeoSystems",          cat:"boutique",   row:10, col:6,  target:"DIB SMB",                    fw:"CMMC, GovCon ERP",                           cmmc:"High",                     price:"Boutique advisory",   notes:"DIB SMB advisory with GovCon ERP heritage (Deltek). Strong vertical fit.", conf:"medium" },
+  { n:73, s:"Rd", name:"Redspin",             cat:"boutique",   row:10, col:7,  target:"DIB / mid",                  fw:"CMMC L1/L2/L3",                              cmmc:"High (also C3PAO)",        price:"$15K&ndash;$75K/assessment", notes:"Among the first authorized C3PAOs (June 2021). Bridges consulting + assessment.", conf:"high" },
+  { n:74, s:"Et", name:"Etactics",            cat:"boutique",   row:10, col:8,  target:"Healthcare + DIB",           fw:"HIPAA, CMMC",                                cmmc:"Medium",                   price:"Boutique advisory",   notes:"Mixed healthcare/DIB compliance. Generalist boutique.", conf:"low" },
+  { n:75, s:"Co", name:"Coalfire",            cat:"boutique",   row:10, col:9,  target:"Mid&ndash;large",            fw:"FedRAMP, CMMC, PCI",                         cmmc:"High (also C3PAO)",        price:"Specialty advisory",  notes:"Larger specialty firm; strong FedRAMP/3PAO presence. Coalfire Federal authorized as C3PAO Jan 2025. Above the SMB price point.", conf:"high" },
+  { n:76, s:"Sk", name:"Schellman",           cat:"boutique",   row:10, col:10, target:"Mid&ndash;large enterprise", fw:"SOC, ISO, FedRAMP, CMMC",                    cmmc:"Medium&ndash;high (C3PAO)", price:"Specialty advisory",  notes:"Audit firm with strong assurance practice. C3PAO. Mid-large oriented rather than SMB.", conf:"high" },
+  { n:77, s:"Aw", name:"Arctic Wolf",         cat:"mssp",       row:10, col:11, target:"Mid-market MDR",             fw:"SOC + monitoring",                           cmmc:"Medium (controls support)", price:"Mid-market MDR",     notes:"Concierge MDR. Supports detection controls; not GRC-native.", conf:"high" },
+  { n:78, s:"Cw", name:"CrowdStrike",         cat:"mssp",       row:10, col:12, target:"Enterprise EDR",             fw:"EDR / XDR / IR",                             cmmc:"Medium",                   price:"Per-endpoint",         notes:"EDR/XDR leader. Controls-layer foundational, not GRC delivery.", conf:"high" },
+  { n:79, s:"Tw", name:"Trustwave",           cat:"mssp",       row:10, col:13, target:"Mid-market",                 fw:"MSSP / PCI / various",                       cmmc:"Low&ndash;medium",         price:"Mid-market MSSP",      notes:"Long-running MSSP. Diversified; CMMC not a stated lead.", conf:"medium" },
+  { n:80, s:"R7", name:"Rapid7",              cat:"mssp",       row:10, col:14, target:"Mid&ndash;large",            fw:"VM, MDR, SIEM",                              cmmc:"Medium",                   price:"Mid-market MDR",       notes:"Vulnerability management + MDR. Adjacent to CMMC controls layer.", conf:"high" },
+  { n:81, s:"Op", name:"Optiv",               cat:"mssp",       row:10, col:15, target:"Mid&ndash;large enterprise", fw:"Reseller + services",                        cmmc:"Medium",                   price:"Varies",               notes:"Mega-reseller + services. Channel for many GRC products; mixed advisory layer.", conf:"medium" }
+];
+
+const mainEls = E.filter(e => e.row <= 7);
+const series1 = E.filter(e => e.row === 8);
+const series2 = E.filter(e => e.row === 9);
+const series3 = E.filter(e => e.row === 10);
+
+function makeCell(e, useGridPos) {
+  const cat = CATS[e.cat];
+  const styleObj = { backgroundColor: cat.fill, borderColor: cat.border, color: cat.text };
+  if (useGridPos) styleObj.gridRow = String(e.row);
+  styleObj.gridColumn = String(e.col);
+  const cell = el('button', {
+    type: 'button',
+    class: 'el' + (e.gap ? ' gap' : ''),
+    style: styleObj,
+    title: e.name,
+    'aria-label': e.name,
+    data: { num: String(e.n) },
+    onclick: () => showDetail(e)
+  });
+  if (e.gap) {
+    const spark = el('i', { class: 'ti ti-sparkles sparkle', 'aria-hidden': 'true' });
+    cell.appendChild(spark);
+  }
+  cell.appendChild(el('span', { class: 'num' }, [String(e.n)]));
+  cell.appendChild(el('span', { class: 'sym' }, [e.s]));
+  return cell;
+}
+
+const main = document.getElementById('main');
+mainEls.forEach(e => main.appendChild(makeCell(e, true)));
+series1.forEach(e => document.getElementById('series-1').appendChild(makeCell(e, false)));
+series2.forEach(e => document.getElementById('series-2').appendChild(makeCell(e, false)));
+series3.forEach(e => document.getElementById('series-3').appendChild(makeCell(e, false)));
+
+// Mobile fallback: category-grouped list (always rendered; CSS controls visibility)
+const mobileGroups = document.getElementById('mobile-groups');
+Object.entries(CATS).forEach(([key, c]) => {
+  const inCat = E.filter(e => e.cat === key);
+  if (!inCat.length) return;
+  const group = el('div', { class: 'mobile-cat-group', data: { cat: key } });
+  group.appendChild(el('p', { class: 'mobile-cat-label', style: { color: c.text } }, [c.label]));
+  const cellsWrap = el('div', { class: 'mobile-cells' });
+  inCat.forEach(e => {
+    const item = el('button', {
+      type: 'button',
+      class: 'mobile-cell' + (e.gap ? ' gap' : ''),
+      style: { borderColor: c.border, color: c.text },
+      data: { num: String(e.n) },
+      onclick: () => showDetail(e)
+    });
+    item.appendChild(el('span', {
+      class: 'sym',
+      style: { background: c.fill, borderColor: c.border, color: c.text }
+    }, [e.s]));
+    item.appendChild(el('span', null, [e.name]));
+    cellsWrap.appendChild(item);
+  });
+  group.appendChild(cellsWrap);
+  mobileGroups.appendChild(group);
+});
+
+const legend = document.getElementById('legend');
+Object.entries(CATS).forEach(([key, c]) => {
+  const item = el('button', {
+    type: 'button',
+    class: 'legend-item',
+    'aria-pressed': 'false',
+    data: { cat: key },
+    onclick: () => toggleCat(key)
+  });
+  item.appendChild(el('span', {
+    class: 'legend-dot',
+    style: { background: c.fill, border: '1px solid ' + c.border }
+  }));
+  item.appendChild(el('span', null, [c.label]));
+  legend.appendChild(item);
+});
+
+// Cache after init; both NodeLists are static once construction finishes.
+const allCells = document.querySelectorAll('.el, .mobile-cell');
+const legendItems = legend.querySelectorAll('.legend-item');
+const mobileGroupNodes = document.querySelectorAll('.mobile-cat-group');
+
+let activeCat = null;
+const searchInput = document.getElementById('search');
+
+// Compose both filters into one predicate so search and legend can coexist.
+function applyFilters() {
+  const q = searchInput.value.trim().toLowerCase();
+  allCells.forEach(node => {
+    const e = E.find(x => x.n === Number(node.dataset.num));
+    const catHit = !activeCat || e.cat === activeCat;
+    const searchHit = !q || e.name.toLowerCase().includes(q) || e.s.toLowerCase().includes(q) || e.cat.includes(q) || e.notes.toLowerCase().includes(q);
+    node.classList.toggle('dim', !(catHit && searchHit));
+  });
+  mobileGroupNodes.forEach(g => {
+    const hasVisible = g.querySelectorAll('.mobile-cell:not(.dim)').length > 0;
+    g.style.display = hasVisible ? '' : 'none';
+  });
+}
+
+function toggleCat(key) {
+  activeCat = (activeCat === key) ? null : key;
+  legendItems.forEach(li => {
+    const isActive = li.dataset.cat === activeCat;
+    li.classList.toggle('dim', activeCat !== null && !isActive);
+    li.setAttribute('aria-pressed', String(isActive));
+  });
+  applyFilters();
+}
+
+searchInput.addEventListener('input', applyFilters);
+
+document.getElementById('reset').addEventListener('click', () => {
+  searchInput.value = '';
+  activeCat = null;
+  legendItems.forEach(li => { li.classList.remove('dim'); li.setAttribute('aria-pressed', 'false'); });
+  allCells.forEach(node => node.classList.remove('selected'));
+  document.getElementById('detail').classList.remove('show');
+  applyFilters();
+});
+
+// Escape closes the detail panel.
+document.addEventListener('keydown', ev => {
+  if (ev.key !== 'Escape') return;
+  const d = document.getElementById('detail');
+  if (!d.classList.contains('show')) return;
+  d.classList.remove('show');
+  allCells.forEach(node => node.classList.remove('selected'));
+});
+
+function showDetail(e) {
+  allCells.forEach(node => {
+    node.classList.toggle('selected', Number(node.dataset.num) === e.n);
+  });
+  const cat = CATS[e.cat];
+  const d = document.getElementById('detail');
+  while (d.firstChild) d.removeChild(d.firstChild);
+
+  const header = el('div', { class: 'detail-header' });
+  const sym = el('div', { class: 'detail-sym', style: { background: cat.fill, borderColor: cat.border, color: cat.text } });
+  sym.appendChild(el('span', { class: 'num' }, [String(e.n)]));
+  sym.appendChild(el('span', { class: 'sym' }, [e.s]));
+  header.appendChild(sym);
+
+  const meta = el('div', { class: 'detail-meta' });
+  const nameP = el('p', { class: 'detail-name' }, [e.name]);
+  nameP.appendChild(el('span', { class: 'conf ' + e.conf }, [e.conf]));
+  meta.appendChild(nameP);
+  meta.appendChild(el('p', { class: 'detail-cat' }, [cat.label]));
+  header.appendChild(meta);
+
+  const closeBtn = el('button', { class: 'detail-close', type: 'button', 'aria-label': 'Close', onclick: () => {
+    d.classList.remove('show');
+    allCells.forEach(node => node.classList.remove('selected'));
+  } });
+  closeBtn.appendChild(el('i', { class: 'ti ti-x', 'aria-hidden': 'true' }));
+  header.appendChild(closeBtn);
+  d.appendChild(header);
+
+  const grid = el('div', { class: 'detail-grid' });
+  // target, cmmc, price, notes may contain HTML entities or footnote markup → fragment
+  function field(label, value, allowHtml) {
+    const f = el('div', { class: 'detail-field' });
+    f.appendChild(el('div', { class: 'label' }, [label]));
+    const v = el('div', { class: 'value' });
+    if (allowHtml) v.appendChild(htmlFrag(value)); else v.appendChild(document.createTextNode(value));
+    f.appendChild(v);
+    return f;
+  }
+  grid.appendChild(field('Target customer', e.target, true));
+  grid.appendChild(field('CMMC L2 fit', e.cmmc, true));
+  grid.appendChild(field('Frameworks', e.fw, false));
+  grid.appendChild(field('Typical pricing', e.price, true));
+  d.appendChild(grid);
+
+  const notes = el('div', { class: 'detail-notes' });
+  notes.appendChild(htmlFrag(e.notes));
+  d.appendChild(notes);
+
+  d.classList.add('show');
+  d.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  closeBtn.focus();
+}
+})();
+</script>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -211,6 +211,7 @@
             <p>
                 <a href="/">Home</a>
                 <a href="/about.html">About</a>
+                <a href="/market-map.html">Market Map</a>
                 <a href="/privacy.html">Privacy Policy</a>
                 <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 <a href="mailto:contact@eagleridge.io">Contact</a>


### PR DESCRIPTION
## Summary

New public page at `eagleridge.io/market-map.html` — interactive periodic-table-style map of the CMMC services landscape positioning Eagle Ridge in the DIB SMB readiness layer.

- 89 entities across 13 categories (authorities, automation platforms, enterprise GRC, CMMC-native tools, data protection, TPRM, privacy, Big 4 / Tier 1 federal, Tier 2 advisory, boutique CMMC, MSSPs, buyers, and "the gap")
- Category filter + free-text search + footnoted sources + methodology section
- Mobile fallback list view at <640px
- Native `<button>` cells for keyboard/screen-reader accessibility; Escape closes the detail panel; focus management on open
- DOM construction via `el()` factory + `Range.createContextualFragment` for the trusted HTML entity/footnote markup (no `innerHTML =` writes, per repo hook)
- PostHog snippet matches other site pages
- Footer links added to `index.html`, `about.html`, `privacy.html`
- `llms.txt` and `CLAUDE.md` updated

## Insights

Built originally as a draft for investor review; reframed for public marketing. Three persona review agents (target DIB SMB CEO, CMMC market expert, r/CMMC + r/GRC community sentiment) surfaced content/positioning issues that follow-up PRs will address:

- **P1** `bj1w` — Reframe "AI-augmented" positioning (r/CMMC pattern-matches it to bad-consultant archetype unless paired with CUI/SPD handling)
- **P2** `ldvf` — Add Kieri Solutions (most-loved C3PAO in r/CMMC), Cuick Trac, Sentinel Blue, Ardalyst, CyberNines
- **P2** `4xgo` — Recategorize Coalfire and Schellman out of "boutique" (specialty assurance firms, not boutiques)
- **P2** `jfzq` — Tighten $3K price floor with explicit scope statement
- **P2** `6eug` — Format decision (keep periodic table as brand artifact + buyer page, or replace with positioning chart)
- **P3** `dols` — Reconcile reg facts (103 / 1% / 431, DIBCAC framing, GCC High de facto)

The Secureframe National Cybersecurity Summit (May 12 2026) validated a sharper opportunity surfaced by Reddit research: the documentation-burden / living-SSP retainer thesis (bead `wnq4`). Nakasone framed it as "Compliance = following rules; Certification = demonstrating capabilities in a dynamic environment" — the language Eagle Ridge can ride for the next service line.

## CI note

The `validate-llms-txt.yml` workflow does a live HTTP 200 check on every `eagleridge.io` URL in `llms.txt`. The new `/market-map.html` URL won't return 200 until this PR merges and GitHub Pages deploys, so expect a one-time URL-check failure on this PR — structure and drift checks will pass.

## Test plan

- [x] Local server (`python3 -m http.server`) — page renders, no console errors except favicon 404 (preexisting)
- [x] 89 cells present across main grid + 3 series rows + mobile list
- [x] Click cell → detail panel opens, close button auto-focused
- [x] Escape closes detail panel
- [x] Category filter dims correctly, ARIA pressed state toggles
- [x] Search input filters across name/symbol/category/notes
- [x] Combined filter (search AND category) composes correctly
- [x] Mobile view (375/390px) — periodic grid hidden, mobile list shown, reset button hidden
- [x] All four code-review agents passed (a11y, filter composition, escape, missing-element guard)
- [ ] Visual check after GitHub Pages deploys