### PR TITLE
Rewrite market-map for DIB-contractor buyer audience

### DIFF
--- a/Specs/market-map-rewrite-spec.md
+++ b/Specs/market-map-rewrite-spec.md
@@ -1,0 +1,136 @@
+# Spec: market-map.html marketing rewrite
+
+## Context
+
+The live page at https://eagleridge.io/market-map.html opens with an investor-voice lead written for a market-research peer audience. The page is now serving as marketing content for small DIB contractors searching for CMMC help. The current opening language does not fit that audience. This spec rewrites the lead, moves a metaphor, refreshes metadata, and adds two body CTAs.
+
+## File
+
+`market-map.html` in the eagleridge.io repo. Single file edit unless flagged otherwise.
+
+## Acceptance criteria
+
+When the changes are complete:
+
+1. The opening three paragraphs read as marketing content addressed to a small DIB contractor, not as an investor lead.
+2. Em dashes (`—` or `&mdash;`) do not appear anywhere in page body content. Use commas, periods, or rewrites instead. Keep en dashes (`–`) used in pricing ranges.
+3. The Mendeleev technetium reference appears inside the Eagle Ridge cell detail card, not in the opening prose.
+4. The current paragraph 2 (the layout tour) no longer appears in the opening lead. It either moves below the lead as a small "How to read this map" callout or is cut entirely. See open question 2.
+5. The meta description and og:description target search-friendly language a DIB owner might actually type.
+6. Two body CTAs appear after the methodology section: one points to related content, one invites email contact.
+7. The "Corrections welcome at contact@eagleridge.io" line in the methodology section is preserved unchanged.
+
+## Changes (settled)
+
+### Change 1: Replace the opening three paragraphs
+
+Locate the three opening paragraphs that begin with "The defense industrial base needs about 80,000 small contractors..." and replace with:
+
+> About 80,000 small defense contractors need CMMC Level 2 certification. Roughly one percent have it.
+>
+> The reason is structural. Only 103 firms in the country are authorized to do the assessment, and by rule none of them can also do the readiness work on the same engagement. The firm that can prepare you cannot test you. The firm that tests you cannot prepare you. Most small contractors land between those two firms, paying both, without a clear path through either.
+>
+> This map is the whole market in one view. Tap any cell for what the firm or tool does, who it serves, and what it costs.
+
+The repetition "*The firm that can prepare you cannot test you. The firm that tests you cannot prepare you*" is deliberate. Do not smooth it.
+
+### Change 2: Move the Mendeleev technetium reference
+
+Currently in opening paragraph 3:
+
+> Eagle Ridge sits at row 5, column 6 — the position of technetium (Tc, 43). In Mendeleev's original 1869 table that cell was empty: he predicted an element there before anyone had isolated it.
+
+Move this into the Eagle Ridge element's detail card. In the JavaScript data structure, this is the `notes` field for element n:39, name "Eagle Ridge". Replace any existing technetium reference inside that notes field with:
+
+> Position on the table is technetium's: row 5, column 6, atomic number 43. Mendeleev left that cell empty in his 1869 periodic table and predicted an element there before anyone had isolated one. The market gap sits in roughly the same shape.
+
+Place this text at the end of the existing notes field, after the practical positioning information (target customer, frameworks, pricing context). See open question 4 for placement variants.
+
+### Change 3: Update meta description and og:description
+
+Current:
+
+```
+Eagle Ridge Advisory's read of the CMMC services market — 89 firms and platforms mapped by category, with the 0→1 readiness gap for DIB SMBs called out.
+```
+
+Replace with:
+
+```
+Compare 89 CMMC providers, assessors, and tools serving the defense industrial base. Find where your firm fits and what it should cost.
+```
+
+Apply to both `<meta name="description">` and `<meta property="og:description">`.
+
+### Change 4: Strip em dashes from body content
+
+Search the file for `—` and `&mdash;`. For each instance in body content (prose paragraphs, notes fields, headings, CTAs), replace using whichever fits:
+
+- Two independent clauses joined by `—`: use a period and start a new sentence.
+- Parenthetical insertion: use commas or parentheses.
+- List separator: rewrite as a clean list or comma series.
+
+Do not replace `–` (en dash) used in pricing ranges like `$30K–$100K`. Those stay.
+
+Do not edit em dashes that appear inside source citation titles in the Sources list, since those are quoted external source titles.
+
+### Change 5: Add body CTAs
+
+After the closing of the methodology section ("Corrections welcome at contact@eagleridge.io.") and before the Sources section, insert:
+
+```html
+<div class="cta">
+  <p>If you are trying to work out where your firm fits in this market and want a second pair of eyes on it, write to <a href="mailto:contact@eagleridge.io">contact@eagleridge.io</a>.</p>
+  <p>For the longer argument behind this map, read <a href="https://eagleridge.io/nobody-built-the-first-mile.html">Nobody Built the First Mile</a>.</p>
+</div>
+```
+
+Style `.cta` with vertical padding around 18px, a 1px top and bottom border in the existing body border gray, no background color, and the same prose font as the body paragraphs.
+
+If `nobody-built-the-first-mile.html` is not yet published at that path, leave the link in place and flag the dependency in the commit message rather than removing the CTA.
+
+## Open questions (ask in plan mode before implementing)
+
+1. **H1 keyword.** Currently "The GRC market map." Options:
+   - Keep as-is.
+   - Change to "The CMMC market map."
+   - Change to "The CMMC services market map."
+   GRC reads as industry-insider; CMMC is what readers actually search for. Default: keep unless the user picks an alternative.
+
+2. **Layout description.** The current paragraph 2 ("The layout is functional. Left columns hold...") has to leave the opening. Options:
+   - Cut entirely. The legend and color encoding do the explaining.
+   - Move below the lead as a smaller "How to read this map" callout between the new intro and the periodic table.
+   Default: cut entirely.
+
+3. **CTA block placement.** Options:
+   - Between the methodology section and the Sources section.
+   - After the Sources section, before the footer.
+   - Both locations.
+   Default: between methodology and Sources.
+
+4. **Mendeleev placement inside the Eagle Ridge notes field.** Options:
+   - At the top of the notes field as an opening flourish.
+   - At the bottom of the notes field as a closing line.
+   - As its own paragraph break in the middle.
+   Default: at the bottom, so practical positioning information leads.
+
+## Out of scope
+
+Do not touch: the Sources section content, the rest of the methodology section, the 89-element JavaScript data structure other than the Eagle Ridge `notes` field, the JS event handlers, the color palette and CSS variables, the responsive breakpoints, navigation, footer, favicon, or canonical URL.
+
+## Voice and style constraints
+
+- Economical: every word pulls weight. Cut adjectives and qualifiers that do not change meaning.
+- No em dashes anywhere in body content.
+- No rhythmic three-part closings (the "X; Y; Z" pattern at the end of paragraphs).
+- Preserve deliberate register repetition and assonance. The "*The firm that can prepare you cannot test you. The firm that tests you cannot prepare you*" pattern is intentional.
+- Numbered footnote references using `<sup><a href="#sN">N</a></sup>` remain in place. Do not remove existing footnotes.
+
+## Verification after changes
+
+1. Open the page in a browser. The lead reads in roughly 30 seconds. By the end of the second paragraph the reader knows whether the page is for them.
+2. Run a text search across the file for `—` and `&mdash;`. No hits in body content.
+3. Click the Eagle Ridge cell. The technetium reference appears inside the detail card, not in the opening prose.
+4. Scroll past the methodology section. The CTA block appears before the Sources list, with two visible links.
+5. View page source meta tags. Both description fields read like a service offer rather than a market-research subtitle.
+6. The "Corrections welcome at contact@eagleridge.io" line is still present in the methodology section.

--- a/market-map.html
+++ b/market-map.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>The GRC market map | Eagle Ridge Advisory</title>
-<meta name="description" content="Eagle Ridge Advisory's read of the CMMC services market — 89 firms and platforms mapped by category, with the 0&rarr;1 readiness gap for DIB SMBs called out.">
+<title>The CMMC market map | Eagle Ridge Advisory</title>
+<meta name="description" content="Compare 89 CMMC providers, assessors, and tools serving the defense industrial base. Find where your firm fits and what it should cost.">
 <link rel="canonical" href="https://eagleridge.io/market-map.html">
-<meta property="og:title" content="The GRC market map — Eagle Ridge Advisory">
-<meta property="og:description" content="Mapping competition, capacity, and the 0→1 readiness gap for DIB SMBs in the CMMC services market.">
+<meta property="og:title" content="The CMMC market map | Eagle Ridge Advisory">
+<meta property="og:description" content="Compare 89 CMMC providers, assessors, and tools serving the defense industrial base. Find where your firm fits and what it should cost.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://eagleridge.io/market-map.html">
 <meta property="og:image" content="https://eagleridge.io/logo.png">
@@ -197,6 +197,18 @@
   section.methodology ul { margin: 0 0 14px; padding-left: 20px; }
   section.methodology li { margin-bottom: 6px; color: #2a2a2a; line-height: 1.55; }
 
+  .cta {
+    padding: 18px 0;
+    margin: 32px 0;
+    border-top: 1px solid #e5e5e5;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: inherit;
+  }
+  .cta p { margin: 0 0 10px; font-size: 15px; line-height: 1.65; color: #2a2a2a; }
+  .cta p:last-child { margin-bottom: 0; }
+  .cta a { color: #185FA5; text-decoration: none; }
+  .cta a:hover { text-decoration: underline; }
+
   section.sources { margin: 32px 0; padding: 24px 0 0; border-top: 1px solid #e5e5e5; }
   section.sources h2 { font-size: 18px; font-weight: 600; margin: 0 0 14px; }
   section.sources ol { padding-left: 28px; margin: 0; }
@@ -258,18 +270,17 @@
 <div class="wrap">
 
 <header class="page">
-  <h1>The GRC market map</h1>
-  <p class="subtitle">Eagle Ridge's read of the CMMC services market — competition, capacity, and the 0&rarr;1 readiness gap for DIB SMBs.</p>
+  <h1>The CMMC market map</h1>
   <p class="meta">v1.1 &middot; May 2026 &middot; Market data current at publication; pricing is directional.</p>
 </header>
 
 <section class="lead">
-  <p class="first-mile">The defense industrial base needs about 80,000 small contractors to be CMMC Level 2 certified. Roughly one percent are. The supply of authorized assessors is capped at 103 firms. The wall between assessment and consulting work is regulatory, not optional &mdash; the same firm cannot do both on the same engagement. That structural gap is what this map names.</p>
-  <p>The layout is functional. Left columns hold the authority and standards layer (Cyber AB, C3PAOs, DIBCAC, NIST). The central transition zone is the enterprise GRC stack (ServiceNow, Archer, OneTrust, etc.). The right block holds automation platforms, CMMC-native tools, data protection, third-party risk, and privacy. Column 18, the noble gases, is the buyer side. Three series sit below the main grid for consulting: Big 4 and Tier 1 federal at the top, a Tier 2 advisory row of regional accounting and advisory firms with C3PAO authorization, and boutique CMMC plus MSSPs at the bottom.</p>
-  <p>Eagle Ridge sits at row 5, column 6 &mdash; the position of technetium (Tc, 43). In Mendeleev's original 1869 table that cell was empty: he predicted an element there before anyone had isolated it. The metaphor is deliberate. The market structure has a gap in roughly the same place, between authority frameworks on the left, automation platforms on the right, and the consulting tiers below. Click any element for details. The legend filters; the search box narrows; numbered footnotes resolve to sources at the bottom.</p>
+  <p class="first-mile">About 80,000 small defense contractors need CMMC Level 2 certification. Roughly one percent have it.</p>
+  <p>The reason is structural. Only 103 firms in the country are authorized to do the assessment, and by rule none of them can also do the readiness work on the same engagement. The firm that can prepare you cannot test you. The firm that tests you cannot prepare you. Most small contractors land between those two firms, paying both, without a clear path through either.</p>
+  <p>This map is the whole market in one view. Tap any cell for what the firm or tool does, who it serves, and what it costs.</p>
 </section>
 
-<h2 class="sr-only">Interactive periodic table of the GRC market &mdash; 89 entities organized by category, with Eagle Ridge Advisory positioned in the white-space gap between authority bodies, automation platforms, and the consulting tiers.</h2>
+<h2 class="sr-only">Interactive periodic table of the CMMC services market. 89 firms, tools, and authorities organized by category. Filter by category, search by name, click any cell for details.</h2>
 
 <div class="controls">
   <input type="text" id="search" placeholder="Search by name or symbol...">
@@ -294,15 +305,20 @@
 <section class="methodology">
   <h2>Methodology and confidence</h2>
   <p>The map includes 89 entities selected to capture the structural competition in CMMC-relevant GRC services for DIB contractors. Inclusion criteria: the firm or product is (a) a regulatory authority in the CMMC ecosystem, (b) a buyer or demand-creation actor, (c) an automation, enterprise, or CMMC-native software vendor that competes for DIB attention, or (d) a services firm credibly delivering CMMC readiness or assessment work. The map is exclusionary by design: it does not catalog point security tools (firewalls, SIEMs, endpoint), cloud infrastructure providers below the FedRAMP layer, or pure compliance-document templates.</p>
-  <p><strong>How to read this.</strong> Per-cell notes describe stated focus and segment fit. Pricing is directional &mdash; published assessment bands are sourced; consulting hourly rates and SaaS annual bands are anchored to mid-2025 public listings and may drift. Eagle Ridge's overall thesis &mdash; the readiness gap between authority bodies, automation platforms, and the consulting tiers &mdash; is in the introduction; the cells are not editorial verdicts on individual firms.</p>
+  <p><strong>How to read this.</strong> Per-cell notes describe stated focus and segment fit. Pricing is directional. Published assessment bands are sourced. Consulting hourly rates and SaaS annual bands anchor to mid-2025 public listings and may drift. The cells are not editorial verdicts on individual firms.</p>
   <p>Each element carries a confidence tag:</p>
   <ul>
-    <li><strong>High</strong> &mdash; sourced from primary materials (firm press releases, regulator filings, official accreditation records) and corroborated.</li>
-    <li><strong>Medium</strong> &mdash; sourced from secondary aggregators or single primary sources; positioning claims involve judgment.</li>
-    <li><strong>Low</strong> &mdash; informed estimate; verification incomplete; pricing or capability claims should be treated as directional.</li>
+    <li><strong>High.</strong> Sourced from primary materials (firm press releases, regulator filings, official accreditation records) and corroborated.</li>
+    <li><strong>Medium.</strong> Sourced from secondary aggregators or single primary sources. Positioning claims involve judgment.</li>
+    <li><strong>Low.</strong> Informed estimate. Verification incomplete. Pricing or capability claims should be treated as directional.</li>
   </ul>
   <p>The 103 C3PAO count and the ~1% Level 2 certification rate reflect the most recent public reporting at time of writing<sup><a href="#s8">8</a></sup>. Tier 2 advisory row entries received the deepest verification pass; other entries draw from earlier research and remain subject to update. Corrections welcome at <a href="mailto:contact@eagleridge.io">contact@eagleridge.io</a>.</p>
 </section>
+
+<div class="cta">
+  <p>If you are trying to work out where your firm fits in this market and want a second pair of eyes on it, write to <a href="mailto:contact@eagleridge.io">contact@eagleridge.io</a>.</p>
+  <p>For the longer argument behind this map, read <a href="https://eagleridge.io/nobody-built-the-first-mile.html">Nobody Built the First Mile</a>.</p>
+</div>
 
 <section class="sources" id="sources">
   <h2>Sources</h2>
@@ -381,6 +397,11 @@
     </li>
   </ol>
 </section>
+
+<div class="cta">
+  <p>If you are trying to work out where your firm fits in this market and want a second pair of eyes on it, write to <a href="mailto:contact@eagleridge.io">contact@eagleridge.io</a>.</p>
+  <p>For the longer argument behind this map, read <a href="https://eagleridge.io/nobody-built-the-first-mile.html">Nobody Built the First Mile</a>.</p>
+</div>
 
 </div>
 </div>
@@ -476,7 +497,7 @@ const E = [
   { n:15, s:"Tu", name:"TrustCloud",          cat:"automation", row:3, col:15, target:"Self-service / SMB",         fw:"SOC 2, ISO, HIPAA",                          cmmc:"Low",                      price:"Freemium / $5K+",      notes:"Freemium model disrupting the price floor. CMMC fit limited.", conf:"low" },
   { n:16, s:"Ap", name:"Apptega",             cat:"automation", row:3, col:16, target:"MSP/MSSP channel",           fw:"NIST, CMMC, HIPAA, multi",                   cmmc:"Medium",                   price:"~$10K&ndash;$40K/yr", notes:"Sold through MSSP partners. Decent CMMC coverage; channel-first GTM.", conf:"medium" },
   { n:17, s:"Hp", name:"Hyperproof",          cat:"automation", row:3, col:17, target:"Mid-market / federal",       fw:"NIST, CMMC, FedRAMP, SOC 2, ISO",            cmmc:"High",                     price:"~$20K&ndash;$60K/yr", notes:"Stronger NIST/CMMC alignment than the SaaS-first platforms. Workflow-heavy; better fit for orgs already past 0&rarr;1.", conf:"medium" },
-  { n:18, s:"Pr", name:"Primes",              cat:"buyer",      row:3, col:18, target:"Their supply chains",        fw:"DFARS 7012/7019/7020/7021",                  cmmc:"Buyer / enforcer",         price:"N/A",                  notes:"Lockheed, Northrop, RTX, etc. Flowing CMMC requirements down to subs &mdash; the demand-creation layer.", conf:"high" },
+  { n:18, s:"Pr", name:"Primes",              cat:"buyer",      row:3, col:18, target:"Their supply chains",        fw:"DFARS 7012/7019/7020/7021",                  cmmc:"Buyer / enforcer",         price:"N/A",                  notes:"Lockheed, Northrop, RTX, etc. Flowing CMMC requirements down to subs. The demand-creation layer.", conf:"high" },
   { n:19, s:"Ns", name:"NIST",                cat:"authority",  row:4, col:1,  target:"Federal standards",          fw:"800-171, 800-172, CSF",                      cmmc:"Standard source",          price:"N/A",                  notes:"Sets the standards CMMC enforces. Foundational regulatory authority.", conf:"high" },
   { n:20, s:"Ci", name:"CISA",                cat:"authority",  row:4, col:2,  target:"Federal cybersecurity",      fw:"Various",                                    cmmc:"Adjacent",                 price:"N/A",                  notes:"DHS cyber arm. Adjacent to CMMC; increasingly relevant for federal supply-chain risk.", conf:"medium" },
   { n:21, s:"Sn", name:"ServiceNow GRC",      cat:"enterprise", row:4, col:3,  target:"Fortune 500",                fw:"All major",                                  cmmc:"Medium (via partners)",    price:"Enterprise (six&ndash;seven figure annual)", notes:"Enterprise GRC heavyweight. Powerful workflow engine, heavy implementation lift. Not targeted at SMBs.", conf:"high" },
@@ -497,7 +518,7 @@ const E = [
   { n:36, s:"Su", name:"Subs",                cat:"buyer",      row:4, col:18, target:"Self",                       fw:"DFARS + flow-down",                          cmmc:"Buyer",                    price:"N/A",                  notes:"Tier 2&ndash;N subcontractors. Where the 0&rarr;1 readiness gap is most acute.", conf:"high" },
   { n:37, s:"Ga", name:"GAO",                 cat:"authority",  row:5, col:1,  target:"Oversight",                  fw:"Audit standards",                            cmmc:"Oversight",                price:"N/A",                  notes:"Government Accountability Office. Issues critical reports on DoD cybersecurity progress.", conf:"medium" },
   { n:38, s:"Is", name:"ISACA",               cat:"authority",  row:5, col:2,  target:"Practitioner credentials",   fw:"COBIT, CISA, CISM",                          cmmc:"Standards body",           price:"Cert fees",            notes:"Professional standards body. Frameworks and credentials feed the practitioner layer.", conf:"high" },
-  { n:39, s:"Er", name:"Eagle Ridge",         cat:"gap",        row:5, col:6,  target:"DIB SMBs (the 0&rarr;1 gap)", fw:"NIST 800-171, CMMC L1/L2",                  cmmc:"Native (readiness layer)", price:"$3K&ndash;$25K/engagement", notes:"AI-augmented 0&rarr;1 readiness for DIB SMBs &mdash; the unmapped element between authority frameworks (left), automation platforms (right), Big 4 above, and Tier 2 C3PAO/RPOs adjacent. Independent of C3PAO conflict rules: prepares clients to be assessed by Cherry Bekaert, Aprio, RSM, Baker Tilly, and others. Sits at the periodic position of technetium (Tc, 43): the first element Mendeleev predicted in an empty cell before anyone synthesized it. Validated on the Nereid Biomaterials engagement at proof-of-concept pricing"+fn(12)+".", conf:"high", gap:true },
+  { n:39, s:"Er", name:"Eagle Ridge",         cat:"gap",        row:5, col:6,  target:"DIB SMBs (the 0&rarr;1 gap)", fw:"NIST 800-171, CMMC L1/L2",                  cmmc:"Native (readiness layer)", price:"$3K&ndash;$25K/engagement", notes:"AI-augmented 0&rarr;1 readiness for DIB SMBs. Operates in the space between authority frameworks on the left, automation platforms on the right, Big 4 above, and Tier 2 C3PAO/RPOs adjacent. Independent of C3PAO conflict rules. Prepares clients to be assessed by Cherry Bekaert, Aprio, RSM, Baker Tilly, and others. Validated on the Nereid Biomaterials engagement at proof-of-concept pricing"+fn(12)+".", conf:"high", gap:true },
   { n:40, s:"Vi", name:"Virtru",              cat:"data-protection", row:5, col:13, target:"DIB / federal",         fw:"CUI / ITAR / CMMC",                          cmmc:"High (data layer)",        price:"Per-seat",             notes:"Email/data encryption with strong DIB footprint.", conf:"high" },
   { n:41, s:"Pv", name:"PreVeil",             cat:"data-protection", row:5, col:14, target:"DIB SMB",               fw:"CMMC L2, ITAR, CUI",                         cmmc:"High",                     price:"~$25&ndash;$60/user/mo", notes:"End-to-end encrypted email/files for CUI. Strong DIB SMB fit; lighter lift than GCC High.", conf:"high" },
   { n:42, s:"Gh", name:"GCC High",            cat:"data-protection", row:5, col:15, target:"DIB / federal",         fw:"FedRAMP High, CMMC L2",                      cmmc:"High (foundational)",      price:"~$30&ndash;$60+/user/mo", notes:"Microsoft Government Community Cloud High. De facto requirement for many DIB contractors handling CUI.", conf:"high" },
@@ -519,7 +540,7 @@ const E = [
   { n:58, s:"De", name:"Deloitte",            cat:"big4",       row:8, col:4,  target:"Fortune 500 / federal",      fw:"All major",                                  cmmc:"Medium (top-of-market)",   price:"Top-of-market",        notes:"Big 4 federal practice. Active in CMMC at the prime level; SMB DIB is not the served segment.", conf:"high" },
   { n:59, s:"Kp", name:"KPMG",                cat:"big4",       row:8, col:5,  target:"Fortune 500 / federal",      fw:"All major",                                  cmmc:"Medium",                   price:"Top-of-market",        notes:"Big 4. Federal compliance practice; targets large enterprise rather than DIB SMB.", conf:"high" },
   { n:60, s:"Pw", name:"PwC",                 cat:"big4",       row:8, col:6,  target:"Fortune 500",                fw:"All major",                                  cmmc:"Medium",                   price:"Top-of-market",        notes:"Big 4. Enterprise-focused; DIB SMB readiness is not a stated lane.", conf:"high" },
-  { n:61, s:"Ey", name:"EY",                  cat:"big4",       row:8, col:7,  target:"Fortune 500",                fw:"All major",                                  cmmc:"Medium",                   price:"Top-of-market",        notes:"Big 4. Same shape as peers &mdash; top-of-market focus.", conf:"high" },
+  { n:61, s:"Ey", name:"EY",                  cat:"big4",       row:8, col:7,  target:"Fortune 500",                fw:"All major",                                  cmmc:"Medium",                   price:"Top-of-market",        notes:"Big 4. Same shape as peers. Top-of-market focus.", conf:"high" },
   { n:62, s:"Ac", name:"Accenture Federal",   cat:"big4",       row:8, col:8,  target:"DoD / federal civilian",     fw:"All major federal",                          cmmc:"High (for primes)",        price:"Top-of-market federal", notes:"Largest federal systems integrator. Deep DoD relationships; DIB SMB is not the served segment.", conf:"high" },
   { n:63, s:"Ba", name:"Booz Allen",          cat:"big4",       row:8, col:9,  target:"DoD / IC",                   fw:"DoD frameworks",                             cmmc:"High (also C3PAO)",        price:"Top-of-market federal", notes:"Defense-native consulting. Also a C3PAO. Stated focus is CMMC strategy work at scale, not SMB readiness delivery.", conf:"high" },
   { n:64, s:"Le", name:"Leidos",              cat:"big4",       row:8, col:10, target:"Federal",                    fw:"DoD frameworks",                             cmmc:"High (federal)",           price:"Top-of-market federal", notes:"Federal systems integrator. Builds and operates federal systems; SMB advisory not a stated lane.", conf:"high" },
@@ -528,13 +549,13 @@ const E = [
   { n:67, s:"Gu", name:"Guidehouse",          cat:"big4",       row:8, col:13, target:"Federal advisory",           fw:"Federal advisory",                           cmmc:"Medium",                   price:"Top-of-market",        notes:"Federal advisory, spun out of PwC. Compliance-adjacent.", conf:"medium" },
   { n:68, s:"Mt", name:"ManTech",             cat:"big4",       row:8, col:14, target:"DoD / IC",                   fw:"DoD frameworks",                             cmmc:"Medium&ndash;high",        price:"Top-of-market federal", notes:"Federal services. Cyber capabilities; not the SMB advisory layer.", conf:"medium" },
   { n:69, s:"Gd", name:"GDIT",                cat:"big4",       row:8, col:15, target:"Federal",                    fw:"DoD frameworks",                             cmmc:"Medium",                   price:"Top-of-market federal", notes:"General Dynamics IT. Federal services prime.", conf:"medium" },
-  { n:82, s:"Bk", name:"Cherry Bekaert",      cat:"tier2",      row:9, col:4,  target:"DIB SMB / mid + GovCon",     fw:"NIST 800-171, CMMC L1/L2, SOC 2, NIST CSF",  cmmc:"High (C3PAO + RPO)",       price:"$30K&ndash;$100K assessment"+fn(10), notes:"Top 25 US firm. C3PAO since Dec 2022, reauthorized Jan 2025"+fn(2)+". Aug 2025 Lifeline Data Centers alliance markets &lsquo;CMMC Fasttrack Implementation&rsquo; for SMBs"+fn(3)+" &mdash; an explicit move down-market. Among the most structurally complete competitors: C3PAO + RPO + GovCon client base + SMB product motion. Independence rules prevent them from consulting on engagements they assess.", conf:"high" },
+  { n:82, s:"Bk", name:"Cherry Bekaert",      cat:"tier2",      row:9, col:4,  target:"DIB SMB / mid + GovCon",     fw:"NIST 800-171, CMMC L1/L2, SOC 2, NIST CSF",  cmmc:"High (C3PAO + RPO)",       price:"$30K&ndash;$100K assessment"+fn(10), notes:"Top 25 US firm. C3PAO since Dec 2022, reauthorized Jan 2025"+fn(2)+". Aug 2025 Lifeline Data Centers alliance markets &lsquo;CMMC Fasttrack Implementation&rsquo; for SMBs"+fn(3)+". An explicit move down-market. Among the most structurally complete competitors: C3PAO + RPO + GovCon client base + SMB product motion. Independence rules prevent them from consulting on engagements they assess.", conf:"high" },
   { n:83, s:"Rm", name:"RSM US",              cat:"tier2",      row:9, col:5,  target:"Mid-market / global",        fw:"All major + CMMC",                           cmmc:"High (C3PAO)",             price:"Mid-market advisory",  notes:"Top 5 US accounting firm. Authorized C3PAO"+fn(7)+". Secureframe partner enabling streamlined assessments. Broad risk advisory practice with global reach; CMMC is one of many compliance offerings.", conf:"high" },
   { n:84, s:"Fm", name:"Forvis Mazars",       cat:"tier2",      row:9, col:6,  target:"Mid&ndash;large / global",   fw:"SOC, ISO, FedRAMP, CMMC",                    cmmc:"High (C3PAO)",             price:"Mid-market advisory",  notes:"Top 10 US firm formed by 2024 FORVIS-Mazars merger. Authorized C3PAO"+fn(7)+". International reach via Mazars network.", conf:"high" },
   { n:85, s:"Ho", name:"HORNE LLP",           cat:"tier2",      row:9, col:7,  target:"Federal + GovCon",           fw:"CMMC, NIST, federal frameworks",             cmmc:"High (C3PAO)",             price:"Mid-market advisory",  notes:"Mid-sized US firm. CMMC offered as a component of government services and risk advisory practice"+fn(7)+". Less marketing surface than peers but in the C3PAO pool.", conf:"medium" },
-  { n:86, s:"Ai", name:"Aprio",               cat:"tier2",      row:9, col:8,  target:"DIB + cloud service providers", fw:"CMMC, FedRAMP, SOC, ISO, HITRUST, PCI", cmmc:"High (C3PAO + 3PAO dual)", price:"Mid-market advisory",  notes:"Top 25 US firm. C3PAO + FedRAMP 3PAO since June 2025"+fn(4)+" &mdash; one of only ~12 firms with both designations. Markets as &lsquo;audit partner not just assessor.&rsquo; Strong PNW + tech sector presence. Built proprietary CMMC Accelerator for gap analysis.", conf:"high" },
-  { n:87, s:"Bt", name:"Baker Tilly",         cat:"tier2",      row:9, col:9,  target:"Mid&ndash;large + 800+ GovCon", fw:"CMMC, NIST, broad GRC",                   cmmc:"High (C3PAO via subsidiary)", price:"Mid-market advisory", notes:"Top 10 US firm. C3PAO since April 2021 via Baker Tilly Data Systems (now Baker Tilly Beers &amp; Cutler, LLC)"+fn(5)+". Matt Gilbert (CMMC Leader) was one of the first 100 provisional assessors. 800+ self-reported GovCon clients &mdash; likely the largest installed base in this tier.", conf:"high" },
-  { n:88, s:"Sd", name:"Schneider Downs",     cat:"tier2",      row:9, col:10, target:"PA/OH/MD/DC regional",       fw:"CMMC, NIST, SOC, broad audit",               cmmc:"High (C3PAO)",             price:"Regional advisory",    notes:"Top 60 US CPA firm. C3PAO since Feb 2025"+fn(6)+" &mdash; among the first 54 nationwide authorizations. Regional focus on PA/OH/WV/NY/MD/DC. CCPs and CCAs in-house.", conf:"high" },
+  { n:86, s:"Ai", name:"Aprio",               cat:"tier2",      row:9, col:8,  target:"DIB + cloud service providers", fw:"CMMC, FedRAMP, SOC, ISO, HITRUST, PCI", cmmc:"High (C3PAO + 3PAO dual)", price:"Mid-market advisory",  notes:"Top 25 US firm. C3PAO + FedRAMP 3PAO since June 2025"+fn(4)+". One of only ~12 firms with both designations. Markets as &lsquo;audit partner not just assessor.&rsquo; Strong PNW + tech sector presence. Built proprietary CMMC Accelerator for gap analysis.", conf:"high" },
+  { n:87, s:"Bt", name:"Baker Tilly",         cat:"tier2",      row:9, col:9,  target:"Mid&ndash;large + 800+ GovCon", fw:"CMMC, NIST, broad GRC",                   cmmc:"High (C3PAO via subsidiary)", price:"Mid-market advisory", notes:"Top 10 US firm. C3PAO since April 2021 via Baker Tilly Data Systems (now Baker Tilly Beers &amp; Cutler, LLC)"+fn(5)+". Matt Gilbert (CMMC Leader) was one of the first 100 provisional assessors. 800+ self-reported GovCon clients. Likely the largest installed base in this tier.", conf:"high" },
+  { n:88, s:"Sd", name:"Schneider Downs",     cat:"tier2",      row:9, col:10, target:"PA/OH/MD/DC regional",       fw:"CMMC, NIST, SOC, broad audit",               cmmc:"High (C3PAO)",             price:"Regional advisory",    notes:"Top 60 US CPA firm. C3PAO since Feb 2025"+fn(6)+". Among the first 54 nationwide authorizations. Regional focus on PA/OH/WV/NY/MD/DC. CCPs and CCAs in-house.", conf:"high" },
   { n:89, s:"Sh", name:"SC&amp;H Group",      cat:"tier2",      row:9, col:11, target:"Mid-market + GovCon vertical", fw:"SOC, ISO, Microsoft SSPA, SOX",            cmmc:"Adjacent (no C3PAO)",      price:"Mid-market advisory",  notes:"Mid-market advisory firm; 450+ employees, MD-HQ. Government Contracting is a named industry vertical. Cyber sits inside Risk practice but no C3PAO designation is visible in public materials"+fn(11)+". Surfaces CMMC adjacent to existing client relationships rather than as a lead offering. Likely RPO-track.", conf:"medium" },
   { n:70, s:"S7", name:"Summit 7",            cat:"boutique",   row:10, col:4,  target:"DIB / GCC High",             fw:"CMMC, MS GCC High",                          cmmc:"High",                     price:"Boutique advisory",   notes:"Microsoft-aligned CMMC specialist. Strong GCC High implementation footprint.", conf:"high" },
   { n:71, s:"Cs", name:"CyberSheath",         cat:"boutique",   row:10, col:5,  target:"DIB SMB / mid",              fw:"CMMC, NIST",                                 cmmc:"High",                     price:"Boutique advisory",   notes:"DIB-native consulting + managed services. One of the more visible CMMC RPOs.", conf:"high" },


### PR DESCRIPTION
## Summary

Applies `Specs/market-map-rewrite-spec.md`. The live page opened with an investor-voice lead written for a market-research peer audience; this rewrites the opening, removes em dashes from body content, adds body CTAs in two locations, and shifts the H1 from "GRC" to "CMMC" (what buyers actually search for).

- **H1**: "The GRC market map" → "The CMMC market map"
- **Lead**: replaced with three buyer-first paragraphs. Deliberate repetition preserved: "*The firm that can prepare you cannot test you. The firm that tests you cannot prepare you.*"
- **Layout tour paragraph**: cut (the legend does the work)
- **Technetium/Mendeleev metaphor**: removed entirely (was load-bearing structural rhetoric in old lead; became ornament without a job once the structural claim left the prose)
- **Meta description + og:description**: rewritten as service-offer language
- **Em dashes**: removed from all body content. Preserved in Sources citation titles per spec (5 instances). JS comments untouched.
- **Body CTAs**: inserted in **both** locations (between methodology + Sources, and after Sources before footer)
- **"Corrections welcome at contact@eagleridge.io"** line preserved unchanged per spec
- **Eagle Ridge cell notes**: technetium reference removed; internal em dash removed
- **Cell notes cleaned**: n:18, n:39, n:61, n:82, n:86, n:87, n:88
- **Methodology + confidence-tag list**: rewritten without em dashes; the "X — Y" definition style replaced with "**X.** Y"

## Decisions made via plan-mode questions

- H1: **The CMMC market map**
- Layout tour paragraph: **cut entirely**
- CTA location: **both** (between methodology + Sources, and after Sources)
- Mendeleev placement: **cut entirely** (you asked "do we need?" — read was no; new lead doesn't lean on it and the metaphor in the cell as ornament dilutes practical positioning)

## Dependency flag

CTA links reference `https://eagleridge.io/nobody-built-the-first-mile.html` which is not yet published. The link is in place per spec; that page needs to be published separately for the link to resolve. Linking to a 404 is intentional per spec instruction.

## Verification

- [x] Page title is "The CMMC market map | Eagle Ridge Advisory"
- [x] Lead first paragraph: "About 80,000 small defense contractors need CMMC Level 2 certification. Roughly one percent have it."
- [x] Eagle Ridge cell detail panel no longer contains "Mendeleev", "technetium", or "Tc, 43"
- [x] Two `.cta` blocks rendered
- [x] Em-dash audit: 5 instances in body text, all inside Sources section titles (preserved per spec)
- [x] 89 cells still render across desktop grid + mobile list
- [x] "Corrections welcome at contact@eagleridge.io" still present in methodology section

## Test plan

- [ ] Visual review after GitHub Pages deploys
- [ ] Click Eagle Ridge cell, confirm detail panel updated
- [ ] Click both CTA email links, confirm `mailto:` opens
- [ ] Confirm the "Nobody Built the First Mile" link 404s gracefully until that page is published