### PR TITLE
Raise agent-readability score: structured data, markdown mirrors, discoverability files

### DIFF
--- a/.github/workflows/validate-llms-txt.yml
+++ b/.github/workflows/validate-llms-txt.yml
@@ -43,18 +43,17 @@ jobs:
             errors=$((errors + 1))
           fi
 
-          # Every HTML file in the repo should be referenced
+          # Every public HTML file should be referenced — by either its .html
+          # page or its .md mirror (llms.txt links to the Markdown mirrors).
           for html_file in *.html; do
             [ "$html_file" = "*.html" ] && continue
-            if [ "$html_file" = "index.html" ]; then
-              pattern="https://eagleridge.io/"
-            else
-              pattern="$html_file"
+            [ "$html_file" = "discovery.html" ] && continue  # unlisted intake form (noindex)
+            stem="${html_file%.html}"
+            if grep -qE "(^|/)${stem}\.(md|html)([\")# ]|$)" llms.txt; then
+              continue
             fi
-            if ! grep -q "$pattern" llms.txt; then
-              echo "::warning file=llms.txt::$html_file is not referenced in llms.txt — consider adding it"
-              errors=$((errors + 1))
-            fi
+            echo "::warning file=llms.txt::$html_file (or ${stem}.md) is not referenced in llms.txt — consider adding it"
+            errors=$((errors + 1))
           done
 
           # Must not be empty or trivially small (< 5 lines)
@@ -71,29 +70,38 @@ jobs:
 
           echo "llms.txt structure is valid"
 
-      - name: Verify URLs return 200
+      - name: Verify referenced URLs resolve to repo files
         run: |
+          # Serve the repo locally and probe each referenced URL against the
+          # repo's own files. This validates the links pre-merge (new pages and
+          # .md mirrors aren't live yet) instead of hitting the production site.
+          python3 -m http.server 8080 --directory . &
+          server_pid=$!
+          sleep 2
           urls=$(grep -oE 'https://eagleridge\.io[^)]*' llms.txt | sort -u)
           errors=0
 
           for url in $urls; do
-            # Strip trailing punctuation and fragments for the HTTP check
-            clean_url=$(echo "$url" | sed 's/#.*//')
-            status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$clean_url" || echo "000")
+            # Map the production URL to a local path; drop the domain and fragment.
+            path=$(echo "$url" | sed -E 's#https://eagleridge\.io##; s/#.*//')
+            [ -z "$path" ] && path="/"
+            status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://localhost:8080$path" || echo "000")
             if [ "$status" -ne 200 ]; then
-              echo "::error file=llms.txt::URL $url returned HTTP $status"
+              echo "::error file=llms.txt::$url -> local path '$path' returned HTTP $status"
               errors=$((errors + 1))
             else
               echo "OK: $url ($status)"
             fi
           done
 
+          kill "$server_pid" 2>/dev/null || true
+
           if [ "$errors" -gt 0 ]; then
-            echo "::error::$errors URL(s) in llms.txt are not reachable"
+            echo "::error::$errors referenced URL(s) do not resolve to files in the repo"
             exit 1
           fi
 
-          echo "All URLs in llms.txt are reachable"
+          echo "All referenced URLs resolve to repo files"
 
   drift-check:
     name: Check llms.txt freshness

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md — eagleridge.io
+
+Guidance for AI agents and automated tools reading this site. Eagle Ridge
+Advisory is a cybersecurity-compliance consultancy serving small defense
+contractors and private-equity portfolio companies (CMMC, NIST 800-171,
+SOC 2, ISO 27001, FedRAMP).
+
+## Installation
+
+Nothing to install. This is a static website hosted on GitHub Pages — there
+is no SDK, package, or API client. Read the pages directly over HTTPS.
+
+## Configuration
+
+- **Base URL:** `https://eagleridge.io`
+- **Machine-readable index:** [`/llms.txt`](https://eagleridge.io/llms.txt) — site summary and page list ([llmstxt.org](https://llmstxt.org/) standard)
+- **Sitemaps:** [`/sitemap.xml`](https://eagleridge.io/sitemap.xml) and [`/sitemap.md`](https://eagleridge.io/sitemap.md)
+- **Crawl rules:** [`/robots.txt`](https://eagleridge.io/robots.txt) — `/discovery.html` is intentionally excluded (private intake form)
+- **Markdown mirrors:** every public page has a `.md` twin (e.g. `/about.html` → `/about.md`), also declared per page via `<link rel="alternate" type="text/markdown">`
+- **Structured data:** each page embeds schema.org JSON-LD in a `<script type="application/ld+json">` block
+
+## Usage
+
+To consume the site as an agent:
+
+1. Start with [`/llms.txt`](https://eagleridge.io/llms.txt) for the page list and one-line summaries.
+2. Prefer the `.md` mirror of any page for clean, chrome-free content (the HTML pages carry analytics and styling).
+3. Use the JSON-LD blocks for the entity graph (Organization, articles, glossary terms).
+4. See [`/glossary.html`](https://eagleridge.io/glossary.html) (or [`/glossary.md`](https://eagleridge.io/glossary.md)) for definitions of CMMC and compliance terminology used throughout.
+
+## Contact
+
+- Email: contact@eagleridge.io
+- LinkedIn: https://www.linkedin.com/company/eagle-ridge-advisory/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Eagle Ridge Advisory — eagleridge.io
 
-Static site hosted on GitHub Pages. Four HTML pages, no build tools.
+Static site hosted on GitHub Pages. Hand-written HTML pages, no build tools. `.nojekyll` disables Jekyll so `.md` mirrors are served raw.
 
 ## Files
 
@@ -12,9 +12,16 @@ Static site hosted on GitHub Pages. Four HTML pages, no build tools.
 | `market-map.html` | Public interactive market map of the CMMC services landscape (89 entities, periodic-table layout). Linked from all page footers. |
 | `nobody-built-the-first-mile.html` | Long-form argument behind the market map. Buyer-first prose, cream/brown palette matching about.html. CTA target from market-map. Linked from all page footers. |
 | `privacy.html` | Privacy policy — includes PostHog tracking disclosure |
+| `glossary.html` | CMMC / NIST 800-171 terminology page (DefinedTermSet JSON-LD). Linked from all footers. |
 | `logo.png` | Logo (also: `Geometric Eagle Head Logo.png`) |
 | `CNAME` | Custom domain: `eagleridge.io` |
-| `llms.txt` | LLM-readable site summary ([llmstxt.org](https://llmstxt.org/) standard) — update when pages/services change |
+| `llms.txt` | LLM-readable site summary ([llmstxt.org](https://llmstxt.org/) standard). Page links point to `.md` mirrors — update when pages/services change |
+| `AGENTS.md` | Guidance for AI agents consuming the site (markdown mirrors, sitemaps, JSON-LD) |
+| `robots.txt` | Crawl rules + sitemap pointer; disallows `/discovery.html` |
+| `sitemap.xml`, `sitemap.md` | Generated sitemaps (see generator below) |
+| `*.md` (per page) | Generated Markdown mirrors of each HTML page; declared via `<link rel="alternate" type="text/markdown">` |
+| `.nojekyll` | Disables Jekyll so `.md` mirrors serve as raw static files |
+| `scripts/generate-md-mirrors.py` | Regenerates `.md` mirrors + sitemaps from HTML. Run after editing any page: `uv run --with markdownify --with beautifulsoup4 python scripts/generate-md-mirrors.py` |
 | `.github/workflows/validate-llms-txt.yml` | PR check: validates llms.txt structure, URL liveness, and drift from HTML changes |
 
 ## Do NOT Touch (during routine site edits)

--- a/about.html
+++ b/about.html
@@ -5,6 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About | Eagle Ridge Advisory</title>
     <meta name="description" content="About Eagle Ridge Advisory - Technology consulting for private equity and venture capital portfolio companies.">
+    <link rel="canonical" href="https://eagleridge.io/about.html">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://eagleridge.io/about.html">
+    <meta property="og:title" content="About | Eagle Ridge Advisory">
+    <meta property="og:description" content="Eagle Ridge Advisory's expertise, client types, and consulting approach for cybersecurity compliance and due diligence.">
+    <link rel="alternate" type="text/markdown" href="https://eagleridge.io/about.md">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "AboutPage",
+      "name": "About Eagle Ridge Advisory",
+      "url": "https://eagleridge.io/about.html",
+      "description": "Eagle Ridge Advisory's expertise, client types, and consulting approach for cybersecurity compliance and due diligence.",
+      "about": {
+        "@type": "Organization",
+        "name": "Eagle Ridge Advisory",
+        "url": "https://eagleridge.io/",
+        "logo": "https://eagleridge.io/logo.png",
+        "sameAs": ["https://www.linkedin.com/company/eagle-ridge-advisory/"]
+      }
+    }
+    </script>
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
         posthog.init('phc_gKgLr0iMjD1gnLV3yd8lEYWIUWmkIk8BuI6jUG3rTBg', {
@@ -242,6 +264,7 @@
                 <a href="/about.html">About</a>
                 <a href="/market-map.html">Market Map</a>
                 <a href="/nobody-built-the-first-mile.html">First Mile</a>
+                <a href="/glossary.html">Glossary</a>
                 <a href="/privacy.html">Privacy Policy</a>
                 <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 <a href="mailto:contact@eagleridge.io">Contact</a>

--- a/about.md
+++ b/about.md
@@ -1,0 +1,50 @@
+<!-- Markdown mirror of https://eagleridge.io/about.html -->
+
+# About | Eagle Ridge Advisory
+
+# About Eagle Ridge Advisory
+
+Eagle Ridge Advisory is a technology consulting firm specializing in cybersecurity, compliance, and growth strategy for private equity and venture capital portfolio companies.
+
+## What We Do
+
+We help investment firms and their portfolio companies navigate complex technology challenges, from technical due diligence during acquisitions to implementing compliance frameworks that unlock enterprise and government contracts.
+
+### Due Diligence
+
+Technical assessment and risk evaluation for acquisitions. We identify cybersecurity gaps, quantify remediation costs, and build implementation roadmaps aligned with deal timelines.
+
+### Compliance
+
+End-to-end support for ISO 27001, SOC 2, CMMC, and FedRAMP certification. We handle documentation, controls implementation, and audit preparation.
+
+### Growth Strategy
+
+Business development and market analysis for technology companies targeting government and enterprise markets.
+
+## Our Expertise
+
+We bring deep experience in:
+
+* Cybersecurity frameworks (NIST 800-53, ISO 27001, CMMC, FedRAMP)
+* Cloud infrastructure security (AWS, Azure, GCP)
+* Regulatory compliance (GDPR, HIPAA, SOC 2)
+* DevSecOps and secure software development
+* Government contracting and acquisition processes
+
+## Who We Serve
+
+Our clients include:
+
+* Private equity and venture capital firms conducting technical due diligence
+* Portfolio companies preparing for compliance certifications
+* Technology startups targeting enterprise and government markets
+* SMBs seeking to implement enterprise-grade security programs
+
+## Our Approach
+
+We believe in practical, business-focused solutions. Our recommendations balance security best practices with operational realities, ensuring you can implement changes without disrupting business operations.
+
+Ready to discuss your portfolio or compliance needs?
+
+[Get in Touch](mailto:contact@eagleridge.io)

--- a/glossary.html
+++ b/glossary.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glossary | Eagle Ridge Advisory</title>
+    <meta name="description" content="Plain-language definitions of CMMC, NIST 800-171, and cybersecurity compliance terms — CUI, FCI, C3PAO, SPRS, POA&amp;M, SSP, DFARS, and more.">
+    <link rel="canonical" href="https://eagleridge.io/glossary.html">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://eagleridge.io/glossary.html">
+    <meta property="og:title" content="Glossary | Eagle Ridge Advisory">
+    <meta property="og:description" content="Plain-language definitions of CMMC, NIST 800-171, and cybersecurity compliance terms used across the defense industrial base.">
+    <link rel="alternate" type="text/markdown" href="https://eagleridge.io/glossary.md">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "DefinedTermSet",
+      "name": "Eagle Ridge Advisory CMMC & Compliance Glossary",
+      "url": "https://eagleridge.io/glossary.html",
+      "description": "Plain-language definitions of CMMC, NIST 800-171, and cybersecurity compliance terms used across the defense industrial base."
+    }
+    </script>
+    <script>
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        posthog.init('phc_gKgLr0iMjD1gnLV3yd8lEYWIUWmkIk8BuI6jUG3rTBg', {
+            api_host: 'https://us.i.posthog.com',
+            person_profiles: 'identified_only',
+            loaded: function(posthog) {
+                posthog.register({ site: 'eagleridge.io' });
+            }
+        });
+    </script>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #3d2817;
+            background: #f9f6ec;
+        }
+        .skip-link {
+            position: absolute; top: -40px; left: 0;
+            background: #3d2817; color: #fff; padding: 8px 16px;
+            text-decoration: none; z-index: 100;
+        }
+        .skip-link:focus { top: 0; }
+        .container { max-width: 860px; margin: 0 auto; padding: 0 24px; }
+        header { padding: 32px 0; border-bottom: 1px solid #d0cdb8; }
+        .logo { font-size: 1.25rem; font-weight: 700; color: #3d2817; text-decoration: none; }
+        nav a { color: #3d2817; text-decoration: none; margin-left: 20px; }
+        nav a:hover { text-decoration: underline; }
+        .header-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+        main { padding: 48px 0; }
+        h1 { font-size: 2.25rem; margin-bottom: 12px; }
+        .lede { font-size: 1.1rem; color: #5a4632; margin-bottom: 40px; max-width: 640px; }
+        h2 { font-size: 1.4rem; margin: 40px 0 16px; padding-bottom: 8px; border-bottom: 1px solid #d0cdb8; }
+        dl { margin: 0; }
+        dt { font-weight: 700; margin-top: 24px; font-size: 1.05rem; }
+        dd { margin: 4px 0 0; color: #4a3826; }
+        footer { padding: 40px 0; border-top: 1px solid #d0cdb8; text-align: center; }
+        footer a { color: #3d2817; text-decoration: none; margin: 0 12px; }
+        footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <a href="#main" class="skip-link">Skip to content</a>
+    <header>
+        <div class="container header-inner">
+            <a href="/" class="logo">Eagle Ridge Advisory</a>
+            <nav>
+                <a href="/about.html">About</a>
+                <a href="/market-map.html">Market Map</a>
+                <a href="/glossary.html">Glossary</a>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main">
+        <div class="container">
+            <h1>Glossary</h1>
+            <p class="lede">Plain-language definitions of the CMMC, NIST 800-171, and cybersecurity compliance terms we use across this site and in client work. Written for small defense contractors and the buyers evaluating them.</p>
+
+            <h2>CMMC core</h2>
+            <dl>
+                <dt>CMMC (Cybersecurity Maturity Model Certification)</dt>
+                <dd>The U.S. Department of Defense program that verifies a contractor's cybersecurity practices before it can handle sensitive defense information. Required across the defense supply chain under the CMMC 2.0 framework.</dd>
+
+                <dt>CMMC Level 1</dt>
+                <dd>The baseline tier: 15 basic safeguarding requirements for companies handling only Federal Contract Information (FCI). Met through annual self-assessment.</dd>
+
+                <dt>CMMC Level 2</dt>
+                <dd>The tier for companies handling Controlled Unclassified Information (CUI): the 110 security requirements of NIST SP 800-171. Most contracts require a third-party (C3PAO) assessment every three years.</dd>
+
+                <dt>CMMC Level 3</dt>
+                <dd>The highest tier, adding requirements from NIST SP 800-172 for the most sensitive programs. Assessed by the government (DIBCAC).</dd>
+            </dl>
+
+            <h2>Information types</h2>
+            <dl>
+                <dt>CUI (Controlled Unclassified Information)</dt>
+                <dd>Government information that is sensitive but not classified — for example technical drawings, specifications, or program data. Handling CUI triggers CMMC Level 2 obligations.</dd>
+
+                <dt>FCI (Federal Contract Information)</dt>
+                <dd>Information provided by or generated for the government under a contract that is not intended for public release. Handling FCI triggers CMMC Level 1.</dd>
+
+                <dt>SPD (Security Protection Data)</dt>
+                <dd>Configuration and security data about the systems that protect CUI — for example log data, vulnerability scan results, or encryption settings. Increasingly relevant when external tools or AI systems touch the protected environment.</dd>
+            </dl>
+
+            <h2>Standards and regulations</h2>
+            <dl>
+                <dt>NIST SP 800-171</dt>
+                <dd>The catalog of 110 security requirements protecting CUI in non-federal systems. It is the technical backbone of CMMC Level 2.</dd>
+
+                <dt>NIST SP 800-53</dt>
+                <dd>The broader federal control catalog used by government systems and FedRAMP. NIST 800-171 is derived from a subset of these controls.</dd>
+
+                <dt>DFARS 252.204-7012</dt>
+                <dd>The contract clause requiring contractors to safeguard covered defense information and report cyber incidents within 72 hours.</dd>
+
+                <dt>DFARS 252.204-7019 / 7020</dt>
+                <dd>Clauses requiring contractors to post a current NIST 800-171 self-assessment score in SPRS (7019) and to allow government verification (7020).</dd>
+
+                <dt>DFARS 252.204-7021</dt>
+                <dd>The clause that makes CMMC certification a condition of contract award once the program is fully phased in.</dd>
+            </dl>
+
+            <h2>Assessment and evidence</h2>
+            <dl>
+                <dt>C3PAO (Certified Third-Party Assessment Organization)</dt>
+                <dd>An organization authorized by the Cyber AB to conduct official CMMC Level 2 assessments. A C3PAO certifies; it does not perform the readiness work that precedes the assessment.</dd>
+
+                <dt>SSP (System Security Plan)</dt>
+                <dd>The document describing how an organization meets each of the 110 requirements — system boundary, responsibilities, and implementation detail. The central artifact in any assessment.</dd>
+
+                <dt>POA&amp;M (Plan of Action and Milestones)</dt>
+                <dd>A tracked list of unmet requirements with remediation steps and dates. Under CMMC only a limited set of lower-weight controls are POA&amp;M-eligible, and they must be closed within 180 days.</dd>
+
+                <dt>SPRS (Supplier Performance Risk System)</dt>
+                <dd>The DoD system where contractors post their NIST 800-171 self-assessment score (out of a maximum of 110, using the official weighted methodology).</dd>
+
+                <dt>Conditional vs. Final certification</dt>
+                <dd>A Conditional status is granted when an organization meets the score threshold but still has open POA&amp;M items; Final status is granted once those items are closed and verified.</dd>
+            </dl>
+
+            <h2>Adjacent frameworks</h2>
+            <dl>
+                <dt>SOC 2</dt>
+                <dd>An attestation report on a service organization's controls for security, availability, and related criteria — common for SaaS vendors and often requested in commercial due diligence.</dd>
+
+                <dt>ISO 27001</dt>
+                <dd>An international standard for an Information Security Management System (ISMS), certified by an accredited body.</dd>
+
+                <dt>FedRAMP</dt>
+                <dd>The U.S. government program standardizing security assessment and authorization for cloud services sold to federal agencies.</dd>
+
+                <dt>DIB (Defense Industrial Base)</dt>
+                <dd>The network of companies that supply the U.S. military — from primes to the small contractors several tiers down who are most affected by CMMC.</dd>
+
+                <dt>RPO / RP (Registered Provider Organization / Registered Practitioner)</dt>
+                <dd>Advisors authorized by the Cyber AB to provide CMMC readiness consulting (not assessment). Eagle Ridge operates in the readiness lane.</dd>
+            </dl>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>
+                <a href="/">Home</a>
+                <a href="/about.html">About</a>
+                <a href="/market-map.html">Market Map</a>
+                <a href="/nobody-built-the-first-mile.html">First Mile</a>
+                <a href="/glossary.html">Glossary</a>
+                <a href="/privacy.html">Privacy Policy</a>
+                <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+                <a href="mailto:contact@eagleridge.io">Contact</a>
+            </p>
+            <p style="margin-top: 16px;">&copy; 2026 Eagle Ridge Advisory. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,83 @@
+<!-- Markdown mirror of https://eagleridge.io/glossary.html -->
+
+# Glossary | Eagle Ridge Advisory
+
+# Glossary
+
+Plain-language definitions of the CMMC, NIST 800-171, and cybersecurity compliance terms we use across this site and in client work. Written for small defense contractors and the buyers evaluating them.
+
+## CMMC core
+
+CMMC (Cybersecurity Maturity Model Certification)
+:   The U.S. Department of Defense program that verifies a contractor's cybersecurity practices before it can handle sensitive defense information. Required across the defense supply chain under the CMMC 2.0 framework.
+
+CMMC Level 1
+:   The baseline tier: 15 basic safeguarding requirements for companies handling only Federal Contract Information (FCI). Met through annual self-assessment.
+
+CMMC Level 2
+:   The tier for companies handling Controlled Unclassified Information (CUI): the 110 security requirements of NIST SP 800-171. Most contracts require a third-party (C3PAO) assessment every three years.
+
+CMMC Level 3
+:   The highest tier, adding requirements from NIST SP 800-172 for the most sensitive programs. Assessed by the government (DIBCAC).
+
+## Information types
+
+CUI (Controlled Unclassified Information)
+:   Government information that is sensitive but not classified — for example technical drawings, specifications, or program data. Handling CUI triggers CMMC Level 2 obligations.
+
+FCI (Federal Contract Information)
+:   Information provided by or generated for the government under a contract that is not intended for public release. Handling FCI triggers CMMC Level 1.
+
+SPD (Security Protection Data)
+:   Configuration and security data about the systems that protect CUI — for example log data, vulnerability scan results, or encryption settings. Increasingly relevant when external tools or AI systems touch the protected environment.
+
+## Standards and regulations
+
+NIST SP 800-171
+:   The catalog of 110 security requirements protecting CUI in non-federal systems. It is the technical backbone of CMMC Level 2.
+
+NIST SP 800-53
+:   The broader federal control catalog used by government systems and FedRAMP. NIST 800-171 is derived from a subset of these controls.
+
+DFARS 252.204-7012
+:   The contract clause requiring contractors to safeguard covered defense information and report cyber incidents within 72 hours.
+
+DFARS 252.204-7019 / 7020
+:   Clauses requiring contractors to post a current NIST 800-171 self-assessment score in SPRS (7019) and to allow government verification (7020).
+
+DFARS 252.204-7021
+:   The clause that makes CMMC certification a condition of contract award once the program is fully phased in.
+
+## Assessment and evidence
+
+C3PAO (Certified Third-Party Assessment Organization)
+:   An organization authorized by the Cyber AB to conduct official CMMC Level 2 assessments. A C3PAO certifies; it does not perform the readiness work that precedes the assessment.
+
+SSP (System Security Plan)
+:   The document describing how an organization meets each of the 110 requirements — system boundary, responsibilities, and implementation detail. The central artifact in any assessment.
+
+POA&M (Plan of Action and Milestones)
+:   A tracked list of unmet requirements with remediation steps and dates. Under CMMC only a limited set of lower-weight controls are POA&M-eligible, and they must be closed within 180 days.
+
+SPRS (Supplier Performance Risk System)
+:   The DoD system where contractors post their NIST 800-171 self-assessment score (out of a maximum of 110, using the official weighted methodology).
+
+Conditional vs. Final certification
+:   A Conditional status is granted when an organization meets the score threshold but still has open POA&M items; Final status is granted once those items are closed and verified.
+
+## Adjacent frameworks
+
+SOC 2
+:   An attestation report on a service organization's controls for security, availability, and related criteria — common for SaaS vendors and often requested in commercial due diligence.
+
+ISO 27001
+:   An international standard for an Information Security Management System (ISMS), certified by an accredited body.
+
+FedRAMP
+:   The U.S. government program standardizing security assessment and authorization for cloud services sold to federal agencies.
+
+DIB (Defense Industrial Base)
+:   The network of companies that supply the U.S. military — from primes to the small contractors several tiers down who are most affected by CMMC.
+
+RPO / RP (Registered Provider Organization / Registered Practitioner)
+:   Advisors authorized by the Cyber AB to provide CMMC readiness consulting (not assessment). Eagle Ridge operates in the readiness lane.

--- a/index.html
+++ b/index.html
@@ -5,6 +5,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Eagle Ridge Advisory | Cybersecurity Compliance for Business & PE</title>
     <meta name="description" content="Cybersecurity compliance consulting for small businesses and PE portfolio companies. CMMC, SOC 2, ISO 27001, and FedRAMP implementation. Due diligence and compliance roadmaps.">
+    <link rel="canonical" href="https://eagleridge.io/">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://eagleridge.io/">
+    <meta property="og:title" content="Eagle Ridge Advisory | Cybersecurity Compliance for Business & PE">
+    <meta property="og:description" content="Cybersecurity compliance consulting for small businesses and PE portfolio companies. CMMC, SOC 2, ISO 27001, and FedRAMP implementation, due diligence, and compliance roadmaps.">
+    <link rel="alternate" type="text/markdown" href="https://eagleridge.io/index.md">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Eagle Ridge Advisory",
+      "url": "https://eagleridge.io/",
+      "logo": "https://eagleridge.io/logo.png",
+      "description": "Cybersecurity compliance consulting for small businesses and private equity portfolio companies. CMMC, SOC 2, ISO 27001, and FedRAMP implementation, due diligence, and compliance roadmaps.",
+      "email": "contact@eagleridge.io",
+      "sameAs": ["https://www.linkedin.com/company/eagle-ridge-advisory/"]
+    }
+    </script>
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
         posthog.init('phc_gKgLr0iMjD1gnLV3yd8lEYWIUWmkIk8BuI6jUG3rTBg', {
@@ -513,6 +531,7 @@
                 <a href="/about.html" style="color: #3d2817; text-decoration: none; margin: 0 12px;">About</a>
                 <a href="/market-map.html" style="color: #3d2817; text-decoration: none; margin: 0 12px;">Market Map</a>
                 <a href="/nobody-built-the-first-mile.html" style="color: #3d2817; text-decoration: none; margin: 0 12px;">First Mile</a>
+                <a href="/glossary.html" style="color: #3d2817; text-decoration: none; margin: 0 12px;">Glossary</a>
                 <a href="/privacy.html" style="color: #3d2817; text-decoration: none; margin: 0 12px;">Privacy Policy</a>
                 <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer" style="color: #3d2817; text-decoration: none; margin: 0 12px;">LinkedIn</a>
                 <a href="mailto:contact@eagleridge.io" style="color: #3d2817; text-decoration: none; margin: 0 12px;">Contact</a>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,64 @@
+<!-- Markdown mirror of https://eagleridge.io/ -->
+
+# Eagle Ridge Advisory | Cybersecurity Compliance for Business & PE
+
+# Eliminate the security poverty line.
+
+We help companies implement cybersecurity compliance frameworks — CMMC, SOC 2, ISO 27001, FedRAMP — so they can win government and enterprise contracts without building a security team from scratch.
+
+# Cybersecurity compliance, made practical.
+
+From first audit to full certification — we get you there.
+
+[### Small Business Leaders
+
+Need CMMC, SOC 2, or ISO 27001 to win contracts? We build your compliance program from the ground up — without the overhead of a full security team.](#contact-form)
+[### PE/VC & Due Diligence Teams
+
+Evaluating a target's security posture? We run technical due diligence, quantify remediation costs, and build post-acquisition compliance roadmaps.](#contact-form)
+
+## What We Do
+
+## Cybersecurity Due Diligence
+
+Technical assessment and risk evaluation for portfolio companies. We identify gaps, quantify remediation costs, and build implementation roadmaps that align with deal timelines.
+
+## Compliance Implementation
+
+End-to-end support for ISO 27001, SOC 2 Type 2, CMMC, and FedRAMP certification. We handle documentation, controls implementation, and audit preparation.
+
+## Go-to-Market Strategy
+
+Business development and market analysis for technology companies. We help portfolio companies identify opportunities, build sales infrastructure, and accelerate growth.
+
+## Compliance Frameworks
+
+We implement and audit against industry-standard security frameworks required for government and enterprise contracts.
+
+ISO 27001
+
+SOC 2 Type 2
+
+CMMC
+
+FedRAMP
+
+NIST 800-53
+
+GDPR
+
+15+
+
+Companies advised
+
+## Let's talk about your compliance needs.
+
+Get in touch to discuss due diligence, compliance, or growth strategy.
+
+Name
+
+Email
+
+Message
+
+Send Message

--- a/llms.txt
+++ b/llms.txt
@@ -4,11 +4,12 @@
 
 ## Pages
 
-- [Homepage](https://eagleridge.io/): Services overview, compliance frameworks, and contact form
-- [About](https://eagleridge.io/about.html): Expertise, client types, and consulting approach
-- [Market Map](https://eagleridge.io/market-map.html): Eagle Ridge's view of the CMMC services market — 89 firms and platforms mapped by category, with the 0→1 readiness gap for DIB SMBs called out
-- [Nobody Built the First Mile](https://eagleridge.io/nobody-built-the-first-mile.html): Long-form argument behind the market map. The structural gap between CMMC assessors and small DIB contractors who need readiness work, and why the window to fix it is closing
-- [Privacy Policy](https://eagleridge.io/privacy.html): Data handling and analytics disclosure
+- [Homepage](https://eagleridge.io/index.md): Services overview, compliance frameworks, and contact form
+- [About](https://eagleridge.io/about.md): Expertise, client types, and consulting approach
+- [Market Map](https://eagleridge.io/market-map.md): Eagle Ridge's view of the CMMC services market — 89 firms and platforms mapped by category, with the 0→1 readiness gap for DIB SMBs called out
+- [Nobody Built the First Mile](https://eagleridge.io/nobody-built-the-first-mile.md): Long-form argument behind the market map. The structural gap between CMMC assessors and small DIB contractors who need readiness work, and why the window to fix it is closing
+- [Glossary](https://eagleridge.io/glossary.md): Plain-language definitions of CMMC, NIST 800-171, and cybersecurity compliance terms (CUI, FCI, C3PAO, SPRS, POA&M, SSP, DFARS)
+- [Privacy Policy](https://eagleridge.io/privacy.md): Data handling and analytics disclosure
 
 ## Services
 

--- a/market-map.html
+++ b/market-map.html
@@ -10,6 +10,21 @@
 <meta property="og:description" content="Compare 89 CMMC providers, assessors, and tools serving the defense industrial base. Find where your firm fits and what it should cost.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://eagleridge.io/market-map.html">
+<link rel="alternate" type="text/markdown" href="https://eagleridge.io/market-map.md">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "The CMMC market map | Eagle Ridge Advisory",
+  "url": "https://eagleridge.io/market-map.html",
+  "description": "Compare 89 CMMC providers, assessors, and tools serving the defense industrial base. Find where your firm fits and what it should cost.",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Eagle Ridge Advisory",
+    "url": "https://eagleridge.io/"
+  }
+}
+</script>
 <meta property="og:image" content="https://eagleridge.io/logo.png">
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
@@ -413,6 +428,7 @@
       <a href="/about.html">About</a>
       <a href="/market-map.html">Market Map</a>
       <a href="/nobody-built-the-first-mile.html">First Mile</a>
+      <a href="/glossary.html">Glossary</a>
       <a href="/privacy.html">Privacy Policy</a>
       <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
       <a href="mailto:contact@eagleridge.io">Contact</a>

--- a/market-map.md
+++ b/market-map.md
@@ -1,0 +1,94 @@
+<!-- Markdown mirror of https://eagleridge.io/market-map.html -->
+
+# The CMMC market map | Eagle Ridge Advisory
+
+About 80,000 small defense contractors need CMMC Level 2 certification. Roughly one percent have it.
+
+The reason is structural. Only 103 firms in the country are authorized to do the assessment, and by rule none of them can also do the readiness work on the same engagement. The firm that can prepare you cannot test you. The firm that tests you cannot prepare you. Most small contractors land between those two firms, paying both, without a clear path through either.
+
+This map is the whole market in one view. Tap any cell for what the firm or tool does, who it serves, and what it costs.
+
+## Interactive periodic table of the CMMC services market. 89 firms, tools, and authorities organized by category. Filter by category, search by name, click any cell for details.
+
+Reset
+
+Tier 1 federal & Big 4 consulting
+
+Tier 2 regional advisory (C3PAO + RPO hybrids)
+
+Boutique CMMC consulting & MSSPs
+
+Tap a firm for details. (The full periodic grid is available on larger screens.)
+
+## Methodology and confidence
+
+The map includes 89 entities selected to capture the structural competition in CMMC-relevant GRC services for DIB contractors. Inclusion criteria: the firm or product is (a) a regulatory authority in the CMMC ecosystem, (b) a buyer or demand-creation actor, (c) an automation, enterprise, or CMMC-native software vendor that competes for DIB attention, or (d) a services firm credibly delivering CMMC readiness or assessment work. The map is exclusionary by design: it does not catalog point security tools (firewalls, SIEMs, endpoint), cloud infrastructure providers below the FedRAMP layer, or pure compliance-document templates.
+
+**How to read this.** Per-cell notes describe stated focus and segment fit. Pricing is directional. Published assessment bands are sourced. Consulting hourly rates and SaaS annual bands anchor to mid-2025 public listings and may drift. The cells are not editorial verdicts on individual firms.
+
+Each element carries a confidence tag:
+
+* **High.** Sourced from primary materials (firm press releases, regulator filings, official accreditation records) and corroborated.
+* **Medium.** Sourced from secondary aggregators or single primary sources. Positioning claims involve judgment.
+* **Low.** Informed estimate. Verification incomplete. Pricing or capability claims should be treated as directional.
+
+The 103 C3PAO count and the ~1% Level 2 certification rate reflect the most recent public reporting at time of writing[8](#s8). Tier 2 advisory row entries received the deepest verification pass; other entries draw from earlier research and remain subject to update. Corrections welcome at [contact@eagleridge.io](mailto:contact@eagleridge.io).
+
+If you are trying to work out where your firm fits in this market and want a second pair of eyes on it, write to [contact@eagleridge.io](mailto:contact@eagleridge.io).
+
+For the longer argument behind this map, read [Nobody Built the First Mile](https://eagleridge.io/nobody-built-the-first-mile.html).
+
+## Sources
+
+1. **The Cyber AB — Pre-Authorized C3PAOs & Authorization Requirements.**
+   The Cybersecurity Maturity Model Certification Accreditation Body, Inc. Official directory and authorization criteria for C3PAOs.
+   [cyberab.org/Pre-Authorized-C3PAOs](https://cyberab.org/Pre-Authorized-C3PAOs)
+   · [R2001 Authorization Requirements (Jan 2026)](https://cyberab.org/Portals/0/Documents/R2001-C3PAO%20Authorization%20Requirements%20JAN2026.pdf)
+   High confidence
+2. **Cherry Bekaert Secures Reauthorization as CMMC Third-Party Assessment Organization.**
+   PRNewswire, January 16, 2025. Authorization ID C0125-CBA-034. Documents reauthorization under updated 32 CFR Part 170 framework.
+   [prnewswire.com](https://www.prnewswire.com/news-releases/cherry-bekaert-secures-reauthorization-as-cmmc-third-party-assessment-organization-302353419.html)
+   High confidence
+3. **Cherry Bekaert Collaborates With Lifeline Data Centers for Streamlined CMMC Compliance.**
+   PRNewswire, August 26, 2025. Describes "CMMC Fasttrack Implementation" model targeting SMBs.
+   [prnewswire.com](https://www.prnewswire.com/news-releases/cherry-bekaert-collaborates-with-lifeline-data-centers-for-streamlined-cmmc-compliance-302538030.html)
+   High confidence
+4. **Aprio Earns C3PAO Status to Lead CMMC Assessments and 3PAO Status to Lead FedRAMP Assessments.**
+   Aprio firm news, June 2025. Confirms dual authorization as one of ~12 firms.
+   [aprio.com](https://www.aprio.com/aprio-earns-c3pao-status-to-lead-cmmc-assessments-and-3pao-status-to-lead-fedramp-assessments-and-strengthen-federal-compliance-services-ins-firmnews/)
+   High confidence
+5. **Baker Tilly Achieves Cybersecurity Maturity Model Certification Third-Party Assessor Accreditation.**
+   BusinessWire, April 27, 2021. Confirms C3PAO via Baker Tilly Data Systems subsidiary (now Baker Tilly Beers & Cutler, LLC).
+   [businesswire.com](https://www.businesswire.com/news/home/20210427005083/en/Baker-Tilly-Achieves-Cybersecurity-Maturity-Model-Certification-Third-Party-Assessor-Accreditation)
+   High confidence
+6. **Schneider Downs Achieves C3PAO Authorization to Conduct CMMC Certifications.**
+   Schneider Downs newsroom, February 2025. Among first 54 nationwide C3PAOs authorized.
+   [schneiderdowns.com](https://schneiderdowns.com/schneider-downs-c3pao-authorization-cmmc-certifications/)
+   High confidence
+7. **CMMC C3PAO List — Authorized Assessors.**
+   Secureframe directory of accredited C3PAOs sourced from Cyber AB Marketplace. Confirms RSM US LLP, Forvis Mazars, HORNE LLP, and others as authorized.
+   [secureframe.com/hub/cmmc/c3pao-list](https://secureframe.com/hub/cmmc/c3pao-list)
+   Medium confidence (secondary aggregator)
+8. **CMMC — Low Compliance Rate, Few C3PAOs Hamper Pentagon Program.**
+   ExecutiveGov, early November 2026. Cites the Cyber AB on 103 authorized C3PAOs and reports ~1% Level 2 certification rate among ~100,000 DIB contractors.
+   [executivegov.com](https://www.executivegov.com/articles/cmmc-dow-cybersecurity-c3pao-cio)
+   High confidence
+9. **Understanding CMMC Levels: Best Practices for Compliance Readiness.**
+   Aprio Insights, December 2025. Cites "over 80,000 contractors are expected to fall under Level 2," and assessment availability constraints.
+   [aprio.com](https://www.aprio.com/insights-events/understanding-cmmc-levels-best-practices-for-compliance-readiness-ins-article-tech/)
+   High confidence
+10. **How to Choose a C3PAO for CMMC Level 2: Key Criteria.**
+    Elevate Consult, April 2026. Pricing data: Level 2 assessments $30K–$100K typical; $30K–$50K for 1–50 employee organizations; $120K–$150K+ for 500+.
+    [elevateconsult.com](https://elevateconsult.com/insights/how-to-choose-the-right-c3pao-for-your-cmmc-level-2-assessment-essential-criteria/)
+    Medium confidence
+11. **SC&H Group services — Cybersecurity Advisory & Assessment.**
+    Firm services page. Cyber sits within Risk practice; no C3PAO or RPO designation visible in public materials.
+    [schgroup.com](https://www.schgroup.com/services/risk/cybersecurity-advisory-assessment/)
+    High confidence (corroborated absence)
+12. **Eagle Ridge Advisory — engagement record.**
+    Internal proof point. CMMC Level 2 SSP deliverable at proof-of-concept pricing for an SMB DIB contractor (Nereid Biomaterials, 2026). Validates the readiness-layer thesis at the low end of the SMB segment.
+    High confidence (primary, internal)
+
+If you are trying to work out where your firm fits in this market and want a second pair of eyes on it, write to [contact@eagleridge.io](mailto:contact@eagleridge.io).
+
+For the longer argument behind this map, read [Nobody Built the First Mile](https://eagleridge.io/nobody-built-the-first-mile.html).

--- a/nobody-built-the-first-mile.html
+++ b/nobody-built-the-first-mile.html
@@ -10,6 +10,29 @@
     <meta property="og:description" content="The structural gap between CMMC assessors and the small defense contractors who need readiness work, and why the window to fix it is closing.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://eagleridge.io/nobody-built-the-first-mile.html">
+    <link rel="alternate" type="text/markdown" href="https://eagleridge.io/nobody-built-the-first-mile.md">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Nobody Built the First Mile",
+      "url": "https://eagleridge.io/nobody-built-the-first-mile.html",
+      "description": "The structural gap between CMMC assessors and the small defense contractors who need readiness work, and why the window to fix it is closing.",
+      "author": {
+        "@type": "Organization",
+        "name": "Eagle Ridge Advisory",
+        "url": "https://eagleridge.io/"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "Eagle Ridge Advisory",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://eagleridge.io/logo.png"
+        }
+      }
+    }
+    </script>
     <meta property="og:image" content="https://eagleridge.io/logo.png">
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
@@ -238,6 +261,7 @@
                 <a href="/">Home</a>
                 <a href="/about.html">About</a>
                 <a href="/market-map.html">Market Map</a>
+                <a href="/glossary.html">Glossary</a>
                 <a href="/privacy.html">Privacy Policy</a>
                 <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 <a href="mailto:contact@eagleridge.io">Contact</a>

--- a/nobody-built-the-first-mile.md
+++ b/nobody-built-the-first-mile.md
@@ -1,0 +1,69 @@
+<!-- Markdown mirror of https://eagleridge.io/nobody-built-the-first-mile.html -->
+
+# Nobody Built the First Mile | Eagle Ridge Advisory
+
+# Nobody Built the First Mile
+
+The structural gap between CMMC assessors and the small defense contractors who need readiness work. And why the window to fix it is closing.
+
+About 80,000 small defense contractors need CMMC Level 2 certification to keep doing the work they already do. Roughly one percent have it. The other 99 percent are stuck somewhere between knowing they need to start and knowing what starting means.
+
+The reason is not laziness, and it is not a software problem. It is structural.
+
+## The wall in the middle of the market
+
+103 firms in the country are authorized to assess a contractor against CMMC Level 2. By rule, no C3PAO can also do the readiness work on the same engagement it audits. Within that engagement, the firm that prepares you cannot test you. The firm that tests you cannot prepare you. This is not a bug. It is the engagement-level independence rule that makes the whole certification mean anything.
+
+So a small contractor needing to get ready has to find someone else. That someone has to be experienced enough to know what assessors will accept, cheap enough to fit a contractor with two or three primes on the book, and willing to engage at the size of the work being asked. The number of firms who clear all three bars at once is small. The number who do it consistently for shops under 100 people is smaller.
+
+## Who is in the middle, and why they are not the answer
+
+Big 4 federal practices do real CMMC work at hourly rates that put them out of reach for any shop below the $50M-revenue line. Their clients are primes and primes' top tiers, not your shop.
+
+Tier 2 accounting firms with C3PAO authorization, including Cherry Bekaert, Aprio, Baker Tilly, RSM, and Forvis Mazars, have started to productize SMB readiness. Cherry Bekaert's "CMMC Fasttrack" launched in mid-2025 as an explicit move down-market. These firms are credible and well-staffed. Their entry-level engagements still start at price points that assume 100-employee shops rather than 30-employee shops.
+
+Boutique CMMC consulting comes closest. Summit 7, CyberSheath, Redspin, Kieri Solutions, and a handful of others are where the community recommendations cluster. Their typical engagements range from roughly $15K at the low end to $30K and up for fuller SMB readiness packages, depending on the firm and scope. Most reserve the deeper work for clients who can spend more.
+
+Automation platforms like Vanta, Drata, and Hyperproof sell software, not preparation. They shipped CMMC modules in 2024. The software is real. It does not replace the work of figuring out what you need, why, and how to write it down.
+
+That leaves Registered Provider Organizations and Registered Practitioners. Roughly 250 RPOs and a few thousand RPs are credentialed to do pre-assessment advisory work. Many of them are excellent. Few of them are economically configured to deliver a complete readiness package to a 30-person shop that needs an SSP, a POA&M, and a remediation plan, end-to-end, for less than the cost of a Sprinter van.
+
+## The first mile
+
+The first mile is the segment that needs to go from zero to a defensible Level 2 readiness package. Owner-operator, 20 to 100 people, one to four prime contracts, CUI in CAD files, no full-time security headcount, and a contracting officer who has started asking when the SSP will be ready.
+
+This is the segment where every firm in the market either cannot work (the C3PAOs), will not work at the price (Big 4, Tier 2 accounting), is not configured to scale into (boutiques at $30K and up), or is selling something adjacent (SaaS platforms).
+
+That segment is who reads this page. If you are the CEO of a 40-person aerospace machine shop, your problem is not finding a list of compliance frameworks. Your problem is finding someone who will sit with you on a Tuesday afternoon and turn your business into a defensible package without charging you what it costs to hire a full-time security director.
+
+Nobody built that. We are building it.
+
+## The window is closing
+
+The reason this is timed and not theoretical: the door does not stay open forever.
+
+Cherry Bekaert's Fasttrack is one of three or four early moves from accounting-firm C3PAOs to productize SMB readiness. More are coming. Vanta and Drata are publishing CMMC walkthroughs aimed at exactly the small-shop segment. The Secureframe National Cybersecurity Summit in May 2026 framed the direction of the entire compliance industry, in General Nakasone's keynote, as a shift from point-in-time audits to continuous certification. The firms moving fastest toward that posture are the firms most likely to push into the SMB segment as the FedRAMP 20x program proves out the model later this year.
+
+The first mile will be served. The only question is whether it is served by firms who understand the texture of a 30-person aerospace shop's day, or by firms who treat that shop as the long tail of a deck slide. A Level 2 certification is, operationally, a contract-retention instrument. The prime does not renew a sub who cannot produce one. We have an opinion about which firms should be doing this work.
+
+## What we do
+
+Eagle Ridge prepares small DIB contractors for CMMC Level 2 assessment. We sit at one point in a supply-chain certification loop. The prime flows the DFARS clause down. The sub needs readiness. The C3PAO does the assessment. The prime needs confirmation. Our work makes the rest of the loop close.
+
+A typical first-mile engagement produces a System Security Plan draft, a POA&M aligned to the controls you do not yet meet, and a remediation roadmap that prioritizes the controls that matter most. Scope, evidence collection, and policy alignment work scales from there.
+
+Pricing runs from $3,000 to $25,000, and at the lower end of that range we are honest about what is and is not in scope. $3K buys you a draft, a remediation plan, and a clear path forward. It does not buy you a fully assessment-ready package with twelve months of evidence and policy training already done. Assessment-ready packages live higher up the range, depending on the size of the shop and the state of the existing program.
+
+We hand off cleanly when the work is done. The C3PAO who eventually assesses you will not be us. By design.
+
+For shops who want to keep the SSP current between assessments, every engagement includes a 90-day post-certification review and a 12-month drift check. The deliverable at each is a dated attestation of SSP currency, the thing your C3PAO will ask for at reassessment. The SSP that is current the day after you certify is the SSP that earns you a clean reassessment three years later. Most firms do not stay that close to their own SSP after the engagement closes. We are designed to.
+
+## The map this page sits behind
+
+We published a map of the CMMC services market at [eagleridge.io/market-map.html](/market-map.html). 89 firms, tools, and authorities. Filter by category, click any cell for details. The map is the inventory. This page is the argument.
+
+If you are the CEO of a 30-person shop with two primes asking when your SSP is ready, the next step is short. Write to [contact@eagleridge.io](mailto:contact@eagleridge.io).
+
+The reply will not be a pitch deck. It will be a short list of questions and an honest scope estimate.
+
+Nobody built the first mile. We are building it.

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy | Eagle Ridge Advisory</title>
     <meta name="description" content="Privacy policy for Eagle Ridge Advisory technology consulting services.">
+    <link rel="canonical" href="https://eagleridge.io/privacy.html">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://eagleridge.io/privacy.html">
+    <meta property="og:title" content="Privacy Policy | Eagle Ridge Advisory">
+    <meta property="og:description" content="How Eagle Ridge Advisory handles data and analytics, including PostHog tracking disclosure.">
+    <link rel="alternate" type="text/markdown" href="https://eagleridge.io/privacy.md">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "name": "Privacy Policy | Eagle Ridge Advisory",
+      "url": "https://eagleridge.io/privacy.html",
+      "description": "How Eagle Ridge Advisory handles data and analytics, including PostHog tracking disclosure.",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "Eagle Ridge Advisory",
+        "url": "https://eagleridge.io/"
+      }
+    }
+    </script>
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
         posthog.init('phc_gKgLr0iMjD1gnLV3yd8lEYWIUWmkIk8BuI6jUG3rTBg', {
@@ -213,6 +233,7 @@
                 <a href="/about.html">About</a>
                 <a href="/market-map.html">Market Map</a>
                 <a href="/nobody-built-the-first-mile.html">First Mile</a>
+                <a href="/glossary.html">Glossary</a>
                 <a href="/privacy.html">Privacy Policy</a>
                 <a href="https://www.linkedin.com/company/eagle-ridge-advisory/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 <a href="mailto:contact@eagleridge.io">Contact</a>

--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,78 @@
+<!-- Markdown mirror of https://eagleridge.io/privacy.html -->
+
+# Privacy Policy | Eagle Ridge Advisory
+
+# Privacy Policy
+
+Last Updated: February 2026
+
+## Overview
+
+Eagle Ridge Advisory ("we," "our," or "us") respects your privacy. This Privacy Policy explains how we collect, use, and protect information when you visit our website or engage our consulting services.
+
+## Information We Collect
+
+We collect information that you provide directly to us, including:
+
+* Contact information (name, email address, phone number)
+* Company information and business inquiries
+* Communications between you and Eagle Ridge Advisory
+
+## How We Use Your Information
+
+We use the information we collect to:
+
+* Respond to your inquiries and provide consulting services
+* Communicate about our services and business opportunities
+* Improve our website and services
+* Comply with legal obligations
+
+## Information Sharing
+
+We do not sell, rent, or share your personal information with third parties except:
+
+* With your explicit consent
+* To comply with legal requirements
+* To protect our rights and safety
+* With service providers who process data on our behalf (see below)
+
+When you submit a message through our contact form, your name, email, and message are transmitted to Web3Forms, a third-party form processing service, solely to deliver the submission to us. Web3Forms does not use your data for any other purpose.
+
+## Data Security
+
+We implement reasonable security measures to protect your information. However, no method of transmission over the internet is 100% secure, and we cannot guarantee absolute security.
+
+## Cookies and Tracking
+
+We use PostHog, a product analytics platform, to understand how visitors interact with our website. PostHog collects anonymous usage data including pages visited, time on site, and general location (country/region level). We also use PostHog's feature testing capabilities to evaluate different versions of page content.
+
+PostHog may set cookies to distinguish unique visitors and maintain session information. You can opt out of tracking by enabling "Do Not Track" in your browser settings or by using a browser extension that blocks analytics scripts.
+
+We do not use this data for advertising, and we do not share analytics data with third parties beyond our analytics provider. For more information about PostHog's privacy practices, visit their privacy policy at posthog.com.
+
+## Third-Party Links
+
+Our website may contain links to third-party websites. We are not responsible for the privacy practices of these external sites.
+
+## Your Rights
+
+You have the right to:
+
+* Access the personal information we hold about you
+* Request correction of inaccurate information
+* Request deletion of your information
+* Opt out of future communications
+
+## Children's Privacy
+
+Our services are not directed to individuals under 18 years of age. We do not knowingly collect information from children.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. Changes will be posted on this page with an updated revision date.
+
+## Contact Us
+
+If you have questions about this Privacy Policy or our privacy practices, please contact us at:
+
+[contact@eagleridge.io](mailto:contact@eagleridge.io)

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /discovery.html
+
+Sitemap: https://eagleridge.io/sitemap.xml

--- a/scripts/generate-md-mirrors.py
+++ b/scripts/generate-md-mirrors.py
@@ -11,6 +11,7 @@ Outputs (committed, served by GitHub Pages):
   - sitemap.xml       XML sitemap for crawlers
   - sitemap.md        human/agent-readable sitemap
 """
+
 from __future__ import annotations
 
 import datetime as dt
@@ -28,7 +29,11 @@ PAGES = [
     ("index.html", "/", "Homepage"),
     ("about.html", "/about.html", "About"),
     ("market-map.html", "/market-map.html", "Market Map"),
-    ("nobody-built-the-first-mile.html", "/nobody-built-the-first-mile.html", "Nobody Built the First Mile"),
+    (
+        "nobody-built-the-first-mile.html",
+        "/nobody-built-the-first-mile.html",
+        "Nobody Built the First Mile",
+    ),
     ("glossary.html", "/glossary.html", "Glossary"),
     ("privacy.html", "/privacy.html", "Privacy Policy"),
 ]
@@ -36,7 +41,7 @@ PAGES = [
 
 def md_path(html_name: str) -> str:
     """Markdown mirror filename for an HTML page."""
-    return html_name[:-len(".html")] + ".md"
+    return html_name[: -len(".html")] + ".md"
 
 
 def extract(html: str) -> tuple[str, str]:

--- a/scripts/generate-md-mirrors.py
+++ b/scripts/generate-md-mirrors.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate Markdown mirrors, sitemap.xml, and sitemap.md from the site's HTML.
+
+These outputs are derived from the HTML pages, so they are generated rather
+than hand-maintained (avoids drift). Re-run after editing any page:
+
+    uv run --with markdownify --with beautifulsoup4 python scripts/generate-md-mirrors.py
+
+Outputs (committed, served by GitHub Pages):
+  - <stem>.md         one Markdown mirror per public page
+  - sitemap.xml       XML sitemap for crawlers
+  - sitemap.md        human/agent-readable sitemap
+"""
+from __future__ import annotations
+
+import datetime as dt
+import pathlib
+
+from bs4 import BeautifulSoup
+from markdownify import markdownify
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+BASE_URL = "https://eagleridge.io"
+
+# (html filename, public path, sitemap label). Order = sitemap order.
+# discovery.html is intentionally excluded (unlisted / noindex).
+PAGES = [
+    ("index.html", "/", "Homepage"),
+    ("about.html", "/about.html", "About"),
+    ("market-map.html", "/market-map.html", "Market Map"),
+    ("nobody-built-the-first-mile.html", "/nobody-built-the-first-mile.html", "Nobody Built the First Mile"),
+    ("glossary.html", "/glossary.html", "Glossary"),
+    ("privacy.html", "/privacy.html", "Privacy Policy"),
+]
+
+
+def md_path(html_name: str) -> str:
+    """Markdown mirror filename for an HTML page."""
+    return html_name[:-len(".html")] + ".md"
+
+
+def extract(html: str) -> tuple[str, str]:
+    """Return (title, markdown) from a page's HTML, stripping chrome/scripts."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    title_tag = soup.find("title")
+    title = title_tag.get_text(strip=True) if title_tag else "Eagle Ridge Advisory"
+
+    for tag in soup(["script", "style", "noscript"]):
+        tag.decompose()
+    for tag in soup.find_all(["header", "footer", "nav"]):
+        tag.decompose()
+
+    content = soup.find("main") or soup.body or soup
+    markdown = markdownify(str(content), heading_style="ATX")
+
+    # Collapse runs of blank lines.
+    lines = [ln.rstrip() for ln in markdown.splitlines()]
+    cleaned: list[str] = []
+    blank = False
+    for ln in lines:
+        if ln == "":
+            if not blank:
+                cleaned.append("")
+            blank = True
+        else:
+            cleaned.append(ln)
+            blank = False
+    return title, "\n".join(cleaned).strip()
+
+
+def write_mirror(html_name: str, public_path: str) -> None:
+    html = (ROOT / html_name).read_text(encoding="utf-8")
+    title, body = extract(html)
+    url = BASE_URL + public_path
+    out = f"<!-- Markdown mirror of {url} -->\n\n# {title}\n\n{body}\n"
+    (ROOT / md_path(html_name)).write_text(out, encoding="utf-8")
+    print(f"  wrote {md_path(html_name)}")
+
+
+def write_sitemap_xml(lastmod: str) -> None:
+    rows = []
+    for html_name, public_path, _ in PAGES:
+        priority = "1.0" if public_path == "/" else "0.7"
+        rows.append(
+            "  <url>\n"
+            f"    <loc>{BASE_URL}{public_path}</loc>\n"
+            f"    <lastmod>{lastmod}</lastmod>\n"
+            f"    <priority>{priority}</priority>\n"
+            "  </url>"
+        )
+    xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        + "\n".join(rows)
+        + "\n</urlset>\n"
+    )
+    (ROOT / "sitemap.xml").write_text(xml, encoding="utf-8")
+    print("  wrote sitemap.xml")
+
+
+def write_sitemap_md() -> None:
+    lines = [
+        "# Eagle Ridge Advisory — Sitemap",
+        "",
+        "Markdown sitemap for agents and readers. Each page also has a `.md` mirror.",
+        "",
+    ]
+    for html_name, public_path, label in PAGES:
+        url = BASE_URL + public_path
+        mirror = BASE_URL + "/" + md_path(html_name)
+        lines.append(f"- [{label}]({url}) — Markdown: [{md_path(html_name)}]({mirror})")
+    (ROOT / "sitemap.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print("  wrote sitemap.md")
+
+
+def main() -> None:
+    lastmod = dt.date.today().isoformat()
+    print("Generating Markdown mirrors:")
+    for html_name, public_path, _ in PAGES:
+        write_mirror(html_name, public_path)
+    print("Generating sitemaps:")
+    write_sitemap_xml(lastmod)
+    write_sitemap_md()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sitemap.md
+++ b/sitemap.md
@@ -1,0 +1,10 @@
+# Eagle Ridge Advisory — Sitemap
+
+Markdown sitemap for agents and readers. Each page also has a `.md` mirror.
+
+- [Homepage](https://eagleridge.io/) — Markdown: [index.md](https://eagleridge.io/index.md)
+- [About](https://eagleridge.io/about.html) — Markdown: [about.md](https://eagleridge.io/about.md)
+- [Market Map](https://eagleridge.io/market-map.html) — Markdown: [market-map.md](https://eagleridge.io/market-map.md)
+- [Nobody Built the First Mile](https://eagleridge.io/nobody-built-the-first-mile.html) — Markdown: [nobody-built-the-first-mile.md](https://eagleridge.io/nobody-built-the-first-mile.md)
+- [Glossary](https://eagleridge.io/glossary.html) — Markdown: [glossary.md](https://eagleridge.io/glossary.md)
+- [Privacy Policy](https://eagleridge.io/privacy.html) — Markdown: [privacy.md](https://eagleridge.io/privacy.md)

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://eagleridge.io/</loc>
+    <lastmod>2026-05-28</lastmod>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://eagleridge.io/about.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://eagleridge.io/market-map.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://eagleridge.io/nobody-built-the-first-mile.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://eagleridge.io/glossary.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://eagleridge.io/privacy.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <priority>0.7</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

Addresses the a14y agent-readability scorecard run against eagleridge.io (was **59/100**, 13 failing checks across 5 pages). Fixes **12 of 13**.

### Per-page HTML `<head>`
- Added `rel="canonical"`, `og:title`, `og:description` to `index`, `about`, `privacy` (`market-map` and `nobody-built` already had them).
- Added schema.org **JSON-LD** to all 5 pages (Organization / AboutPage / WebPage / CollectionPage / Article).
- Added `<link rel="alternate" type="text/markdown">` to every page.
- Added a **Glossary** footer link to all pages.

### New content
- `glossary.html` — CMMC / NIST 800-171 terminology page (`DefinedTermSet` JSON-LD), on-brand, full head meta. Genuine buyer content, not just a checkbox.

### Discoverability (site-wide)
- `robots.txt`, `sitemap.xml`, `sitemap.md`, `AGENTS.md` (Installation/Configuration/Usage sections).
- `.nojekyll` so Markdown mirrors serve as raw static files.
- `llms.txt` page links now point at `.md` mirrors.

### Derived data, generated not hand-typed
- `scripts/generate-md-mirrors.py` produces the per-page `.md` mirrors **and** both sitemaps from the HTML. Re-run after any page edit — avoids drift.

### CI fix
- `validate-llms-txt.yml` previously curled the **live** site, so any newly added page or `.md` link 404'd until merged (chicken-and-egg). Rewrote the URL check to serve the repo locally and probe its own files, and made the "every page referenced" check accept `.md` or `.html`. Robust for all future page additions.

### Not fixed
- `markdown.content-negotiation` requires server-side handling of `Accept: text/markdown`. **GitHub Pages cannot do content negotiation** — would need a different host (e.g. Cloudflare Worker). Left as a known limitation.

## Test plan
- [x] Local verification: served repo, all `llms.txt` URLs + discoverability files return 200; JSON-LD parses on every page; `sitemap.xml` is well-formed; glossary linked from all footers.
- [x] Generator runs clean via `uv`.
- [ ] After merge + Pages deploy, re-run `a14y check https://eagleridge.io/ --mode site` to confirm score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
