### PR TITLE
Insights hub + header nav + AI-view affordances

### DIFF
--- a/docs/design-briefs/copy-page-for-ai-control.md
+++ b/docs/design-briefs/copy-page-for-ai-control.md
@@ -1,0 +1,53 @@
+You are designing a single small UI control for **Eagle Ridge Advisory** (eagleridge.io), a compliance-readiness advisory firm. Produce an **interactive HTML artifact** that mocks up the control in our brand, in several variants and states, so we can pick a direction. This is a visual mockup only — clean, production-quality HTML/CSS, no framework.
+
+## What the control is
+
+The hero concept is a **human ⇄ robot view toggle**: a switch in the page that flips between the normal human-readable page and a **"robot view"** showing the visitor exactly what an AI/LLM sees — the clean Markdown representation of the same page. The point is to let a human *see the machine version*, as a confident signal that this firm is built for the AI era. Our site already generates a clean `.md` mirror of every page (e.g. `/about` → `/about.md`), so the robot view renders that same content.
+
+For comparison, also mock up the **conventional** industry pattern: a "Copy page" / "View as Markdown" button (shipped by Anthropic's docs, Linear, Mintlify, Vercel, DatoCMS). We want to see our distinctive toggle *and* the proven convention side by side, then choose.
+
+
+## Brand system (use these exactly)
+
+**Palette (warm cream + deep brown, editorial):**
+- Page background `--er-bg: #F6F2EA`
+- Panel/paper `--er-paper: #FAF7F0`
+- Ink (headings) `--er-ink: #1A1614`
+- Body ink `--er-ink-soft: #44372F`
+- Muted `--er-mute: #8B7D6E`
+- Hairline rule `--er-rule: #D9D0BF`
+- Accent (primary, deep brown) `--er-accent: #4A2F22`
+- Gold (sparing) `--er-gold: #B08A4E`
+
+**Type:**
+- Serif (headings): **Newsreader** (Georgia fallback)
+- Sans (body/UI): **IBM Plex Sans**
+- Mono (eyebrows, nav, meta — uppercase, letter-spaced ~0.16em): **IBM Plex Mono**
+
+**Voice of the masthead:** logo mark + uppercase wordmark "EAGLE RIDGE ADVISORY" on the left; primary nav (About · Insights · Contact) in uppercase mono on the right, with a small mono "GRC READINESS" tagline. The aesthetic is restrained, trustworthy, print-like — NOT a colorful dev-tools UI. The audience is **non-technical small-business CEOs**, so the control must read as discreet and credible, not gimmicky.
+
+## What to mock up
+
+Render a realistic **page masthead + the start of an article** (an H1 like "Why Readiness Comes Before the Assessment", a date/byline line, a paragraph) so the control can be shown in context. Then present these variant directions, each clearly labeled:
+
+1. **Human ⇄ Robot toggle (LEAD — our distinctive concept).** A small switch/segmented control in the masthead or right of the H1, with two labeled states — e.g. `HUMAN` / `ROBOT` (consider also "Read view / AI view"). Show what happens in BOTH positions:
+   - **Human view (default):** the normal, styled page.
+   - **Robot view (toggled on):** the SAME page content visibly transformed into its machine-readable self — clean Markdown rendered in mono/plain styling (front-matter-ish metadata, `#` headings, a `[link](/path.md)`), as if peeking at what the AI ingests. Make this feel intentional and on-brand, not like a broken page. Explore at least two treatments: (a) the whole article column swaps to the markdown rendering in place, and (b) a side-by-side / split showing human and robot together.
+   - Show the toggle control itself in both states (knob left/right or segment active), plus its keyboard-focus state.
+2. **Split button (the proven convention).** A "Copy page" button with a clipboard icon; a caret opens a small dropdown menu with: `Copy page (Markdown)`, `View as Markdown`. On-brand (mono or sans label, accent or outline treatment). Show placement near/right of the H1. Include states: default (closed), dropdown open, "Copied ✓" confirmation (describe the `aria-live` announcement), keyboard-focus.
+3. **Minimal** — a single quiet text link near the H1: `View as Markdown`. The lowest-key fallback.
+4. **Maximal (for reference only)** — the split button plus dropdown items `Open in ChatGPT` and `Open in Claude` (simple monochrome marks, not full-color logos). Show it so we can judge whether it's too dev-toolsy for our CEO audience.
+
+Lead with and give the most space to **Variant 1 (the toggle)** — that's the direction we're most excited about. Treat 2–4 as comparison options.
+
+## Constraints & details
+
+- Match the existing nav styling: mono, uppercase, ~12px, letter-spacing 0.16em, accent on hover/active. The control should feel like it belongs next to that nav.
+- Accessibility: real `<button>` with an accessible menu (focusable, arrow-key navigable), visible focus, an `aria-live="polite"` "Copied" region, and `aria-label`s on any icon-only items. Tap targets ≥ 44px on mobile. Call these out in annotations.
+- Show light **annotations/callouts** next to each variant explaining the choice (placement, what it does, why it fits or doesn't).
+- Mobile: show how the control collapses / where it sits on a ~375px width.
+- Do NOT invent new brand colors or use bright/SaaS-style gradients. Stay within the palette above.
+
+## Deliverable
+
+One self-contained HTML artifact (inline CSS, system-loaded Google Fonts for Newsreader / IBM Plex Sans / IBM Plex Mono) that I can open in a browser and visually compare all variants and their states. Make the artifact's toggle actually interactive if practical (clicking `HUMAN`/`ROBOT` flips the demo article between styled and markdown views). Lead with and give the most visual weight to **Variant 1, the Human ⇄ Robot toggle** — that's our preferred direction; the Copy-page/Markdown options are shown for comparison.

--- a/docs/recap-2026-06-12-insights-hub-and-nav.md
+++ b/docs/recap-2026-06-12-insights-hub-and-nav.md
@@ -1,0 +1,45 @@
+# Session Recap: Header navigation + Insights content hub
+
+**Date:** 2026-06-12
+**Project:** Eagle Ridge Advisory (eagleridge.io — Astro site in `site/`)
+**PRs:** [#28](https://github.com/eagle-ridge/Eagle-Ridge/pull/28) (open, CI green, awaiting merge)
+**Issues filed:** #26, #27, #29, #30
+
+## What Was Built
+
+The site previously had **no navigation menu** — just a logo lockup and a tagline; pages were reachable only via the footer. This session added:
+
+1. **Primary header nav** — `About · Insights · Contact` in the masthead, with `aria-current` on the active page (threaded from `BaseLayout`'s `path`). Brand-consistent (IBM Plex Mono, uppercase), 44px tap targets, focus-visible, wraps cleanly on mobile (no hamburger). Insights also added to the footer for parity.
+
+2. **Insights content hub** — a new `/insights` blog index where dated articles auto-list from a new `articles` Astro content collection. Each post is one markdown file → its own page at `/insights/<slug>`. Index sorts by `pubDate`, excludes drafts, has an empty-state, and emits `Blog` / `BlogPosting` JSON-LD. Reuses the existing `.prose` styling and the glossary content-collection pattern.
+
+3. **Build pipeline** — `generate-md-mirrors.py` now **auto-discovers** `dist/insights/*.html` → `.md` mirrors + sitemap rows (no per-post edits). `llms.txt` updated. Discovery logs the article count and hard-fails on a blank/fallback `<title>` (since discovered mirrors have no parity-baseline backstop).
+
+4. **One seed article** — "Why Readiness Comes Before the Assessment" (~350 words), author-reviewed and revised for economical prose.
+
+The work was built with **three parallel subagents** (Nav / Hub / Pipeline), then a **4-agent PR review** (code, silent-failure, type-design, comments) that surfaced 4 real fixes, all applied.
+
+## Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Content hub = **Insights blog** (not a resource library) | Dated thinking is the trust signal that converts the CEO buyer; footer already links evergreen assets |
+| Lean nav: **About · Insights · Contact** | Primary buyer journey; Market Map/Glossary stay in the footer |
+| Mirror generator **auto-discovers** articles vs. hardcoded list | New posts need zero pipeline edits |
+| Format dates with **`timeZone: 'UTC'`** | A date-only `pubDate` is parsed as UTC midnight; without this it displayed off-by-one (June 11 vs 12) on a non-UTC build machine |
+| AI-readability affordance = **human ⇄ robot view toggle** (not a Copy-page button) | Distinctive "built for the AI era" brand signal; the conventional Copy-page button reads as too dev-toolsy for CEOs. Design brief written; awaiting mockup (#29) |
+
+## Corrections Applied
+
+- **UTC date off-by-one** — caught in verification; fixed with `timeZone: 'UTC'` on both formatters.
+- **PR-review fixes** — schema `.min(1)` on title/description; suffixed article `<title>` to kill a duplicate H1 in mirrors; `data-md-exclude` on the back-link; hardened `discover_insights()` against silent garbage output.
+- **Roughdraft** was broken (missing `yaml` dep); fixed by installing it into roughdraft's `node_modules` (saved to memory).
+
+## What's Next
+
+- **Merge PR #28** (CI green, reviewed).
+- **#29** — implement the human ⇄ robot AI-view toggle once a claude.ai mockup is chosen (brief at `docs/design-briefs/copy-page-for-ai-control.md`).
+- **#26** — rewrite the stale root `CLAUDE.md` to describe the Astro architecture.
+- **#27** — Insights enhancements (tags/RSS/pagination/author pages) when volume warrants.
+- **#30** — harden the generator to cross-check discovered slugs against the `articles` collection.
+- Author writes the real content series (e.g. "The C3PAO Is Not the End State") into the new hub.

--- a/docs/recap-2026-06-17-ai-view-affordances.md
+++ b/docs/recap-2026-06-17-ai-view-affordances.md
@@ -1,0 +1,72 @@
+# Recap — 2026-06-17: AI-view affordances + responsive hamburger nav
+
+## What this session did
+
+Implemented the Claude Design **"Navigation"** handoff
+(`design_handoff_navigation_md/README.md`, design project
+`5e880330-f3ea-4398-a9f3-a2c603141c98`) onto the Insights article template.
+The nav + Insights hub + `.md`-twin pipeline from this handoff were already
+built on `feature/insights-hub-and-nav` (PR #28) by a prior session; this
+session added the two **machine-readable affordances** and the **responsive
+masthead** the handoff specs.
+
+Commit: `4f57e4e` — pushed to `feature/insights-hub-and-nav` (PR **#28**).
+
+## Changed files (4, no new dependencies)
+
+- **`site/src/pages/insights/[...slug].astro`** — article meta-block gains:
+  - **View as Markdown ⇄ View as page** — URL-addressable via `?view=markdown`
+    (`history.replaceState`), shareable, restores on reload/back-forward,
+    cross-fades. The markdown view is a build-time styled preview of the `.md`
+    twin (YAML frontmatter from `entry.data` + raw body). `data-md-exclude`'d
+    so it never doubles into the generated mirror.
+  - **Send to LLM** — menu deep-links Claude / ChatGPT / Gemini with the `.md`
+    URL prefilled as a prompt (`?q=`); outside-click + Escape dismiss;
+    transient confirmation mirrored to an `aria-live` region.
+- **`site/src/components/Header.astro` + `site/src/styles/global.css`** —
+  responsive masthead: inline nav >720px; hamburger (Lucide menu/x) + 48px
+  stacked panel ≤720px (`aria-expanded`; Escape / link-tap / resize-to-desktop
+  all close it).
+- **`site/src/styles/tokens.css`** — added `--surface-sunken` and motion
+  tokens (`--er-ease`, `--er-dur-fast`, `--er-dur-base`) the handoff
+  references.
+- a11y: focus-visible rings on every new control; `prefers-reduced-motion`
+  disables fades; GRC tagline moved off `--er-mute` (fails WCAG AA at label
+  size) to `--er-ink-soft`. Icons are inlined Lucide glyphs (`code-2`,
+  `file-text`, `sparkles`, `chevron-down`, `menu`, `x`).
+
+## Verification
+
+- ✅ `astro build` clean (8 pages)
+- ✅ `.md` twin mirror clean — controls + md-preview excluded, body not doubled
+- ✅ Parity baselines unaffected (only pre-existing `.html`-vs-clean-URL comment diff)
+- ✅ Playwright-driven: view toggle flips both ways + writes/clears
+  `?view=markdown`; label swaps; Send menu opens; Escape closes; Claude
+  deep-link correctly encoded; `?view=markdown` restores on load; hamburger
+  shows at 375px with desktop nav hidden, panel opens, link-tap closes.
+- ✅ PR #28 CI: "Validate llms.txt" + "Check llms.txt freshness" both pass.
+
+## Open items / decisions deferred to product
+
+1. **Merge PR #28** — ready; awaiting human review/merge.
+2. **Gemini `?q=` prefill is undocumented** — shipped as specced (matches
+   prototype); may not pre-populate. Handoff suggests a clipboard fallback.
+   Left with a code comment. (README open-decision #3.)
+3. **Preview vs. twin frontmatter mismatch** — the in-page preview shows YAML
+   frontmatter; the served `.md` twin (`generate-md-mirrors.py`) uses an HTML
+   comment + `# title`. Functionally fine, not byte-identical. Reconciling
+   means changing the generator + its parity baselines. (README open-decision
+   #1, "confirm".) Out of scope this session.
+4. README open-decisions **#4** (scope = Insights-only first) and **#5** (GRC =
+   label not link) were defaulted per the handoff's recommendations; may want
+   product sign-off.
+
+## Environment notes (background-job harness)
+
+- Bash cwd resets to `/Users/chrismcconnell/.claude` every call. Use
+  `cd /path; cmd` in one command, or absolute paths / `git -C`. Launch the
+  next session from the repo dir to avoid it.
+- Compound commands (`&&`, `||`) are blocked by a global hook — use `;`.
+- Python mirror script deps:
+  `uvx --with beautifulsoup4 --with markdownify python3 scripts/generate-md-mirrors.py`
+  (pinned in `site/scripts/requirements.txt`).

--- a/docs/superpowers/specs/2026-06-12-insights-hub-and-nav-design.md
+++ b/docs/superpowers/specs/2026-06-12-insights-hub-and-nav-design.md
@@ -1,36 +1,39 @@
 # Insights Hub + Header Navigation — Design
-
-**Date:** 2026-06-12
-**Site:** eagleridge.io (Astro static site in `site/`, deployed to Cloudflare Pages)
-**Goal:** Give the site a real header navigation and a content hub ("Insights") where dated articles auto-list from markdown, so a visitor can both *navigate* the site and *learn who Eagle Ridge is* through published thinking.
-
+**Date:** 2026-06-12 **Site:** eagleridge.io (Astro static site in `site/`, deployed to Cloudflare Pages) **Goal:** Give the site a real header navigation and a content hub ("Insights") where dated articles auto-list from markdown, so a visitor can both _navigate_ the site and _learn who Eagle Ridge is_ through published thinking.
 ## Context
-
 - The live site is the Astro rebuild in `site/`. The repo-root `*.html` files are legacy; the root `CLAUDE.md` is stale (still describes hand-written root HTML as canonical).
+  
 - **There is no navigation menu today.** `Header.astro` is a logo lockup + "GRC Readiness" tagline only. Pages are reachable solely via the footer and inline CTAs.
-- An existing `pages` content collection (`src/content.config.ts`, `src/content/pages/*.md`) backs glossary/privacy/essay via thin `.astro` wrappers. There is no *listing* page or blog-style hub.
-- The build runs `scripts/generate-md-mirrors.py`, which emits a `.md` mirror + sitemap entry per page from a **hardcoded `PAGES` list**. It strips `<header>/<footer>/<nav>` and `[data-md-exclude]` from mirrors. A parity oracle (`parity-baseline/`) and a `validate-llms-txt` CI guard against drift.
-
+  
+- An existing `pages` content collection (`src/content.config.ts`, `src/content/pages/*.md`) backs glossary/privacy/essay via thin `.astro` wrappers. There is no _listing_ page or blog-style hub.
+  
+- The build runs `scripts/generate-md-mirrors.py`, which emits a `.md` mirror + sitemap entry per page from a **hardcoded** `PAGES` **list**. It strips `<header>/<footer>/<nav>` and `[data-md-exclude]` from mirrors. A parity oracle (`parity-baseline/`) and a `validate-llms-txt` CI guard against drift.
+  
 ## Decisions (confirmed with user)
-
 1. **Content hub shape:** Insights hub (blog index) — auto-listing dated articles. (Chosen over a curated resource library: the footer already links evergreen assets, and dated thinking is the trust signal that converts the CEO buyer.)
+  
 2. **Nav contents:** Lean — **About · Insights · Contact**. Market Map / Glossary stay in the footer.
+  
 3. **Seed content:** Author writes the real copy; this work seeds **one short starter article** (flagged for user approval) so the hub launches non-empty.
-
+  
 ## Architecture
-
 ### 1. Navigation — `src/components/Header.astro`
 - Add `<nav aria-label="Primary">` inside the existing `.site-header` with three links: **About** (`/about`), **Insights** (`/insights`), **Contact** (`/#contact-form`).
+  
 - Brand-consistent styling (IBM Plex Mono, uppercase, small caps tracking) added to `src/styles/global.css`.
+  
 - `aria-current="page"` on the active link — derived from a `currentPath` prop threaded from `BaseLayout` (which already receives `path`).
+  
 - Responsive: three short links wrap cleanly; **no hamburger** (YAGNI for 3 items). Verify wrap behavior at 360px.
+  
 - Mirrors are unaffected — the generator strips `<header>`/`<nav>`.
-
+  
 ### 2. Footer — `src/components/Footer.astro`
 - Insert an **Insights** link (after About) for nav/footer parity.
-
+  
 ### 3. Content collection — `src/content.config.ts`
 Add an `articles` collection alongside `pages`:
+
 ```ts
 const articles = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/articles' }),
@@ -46,31 +49,36 @@ const articles = defineCollection({
 });
 export const collections = { pages, articles };
 ```
-
 ### 4. Insights index — `src/pages/insights.astro`
 - `getCollection('articles')` → filter `!data.draft` → sort by `pubDate` desc.
+  
 - Render a list of article cards: title (links to article), formatted `pubDate`, `description`, "Read →".
+  
 - Empty-state fallback ("New thinking coming soon") if the collection is empty.
+  
 - `BaseLayout` with `path="/insights"`, `title`, `description`; `Blog` JSON-LD in the head slot.
-
+  
 ### 5. Article template — `src/pages/insights/[...slug].astro`
 - `getStaticPaths()` over `getCollection('articles')` (drafts excluded), one route per article.
+  
 - `render(entry)` into a `.prose container` `<article>`: H1 title, date byline (+ author), "← Back to Insights".
+  
 - `BaseLayout` with `path={`/insights/${entry.id}`}`; `BlogPosting` JSON-LD (headline, datePublished, dateModified, author).
-
+  
 ### 6. Seed article — `src/content/articles/<slug>.md`
 - One ~400-word on-brand starter (working title: "Why readiness comes before the assessment"), plain-language CEO voice, `draft: false`, dated 2026-06-12.
+  
 - Copy flagged in the PR/spec as author-review-pending.
-
+  
 ### 7. Build pipeline — `site/scripts/generate-md-mirrors.py`
-- Keep the static `PAGES` list for fixed pages; **append `/insights` and dynamically-discovered `dist/insights/*.html`** so each article auto-gets a `.md` mirror + sitemap row. No per-post edits.
+- Keep the static `PAGES` list for fixed pages; **append** `/insights` **and dynamically-discovered** `dist/insights/*.html` so each article auto-gets a `.md` mirror + sitemap row. No per-post edits.
+  
 - Preserve existing extraction/strip logic byte-compatibly (parity oracle).
-
+  
 ### 8. `site/public/llms.txt` (or source of it)
 - Add an **Insights** section pointing at `/insights.md` and article `.md` mirrors.
-
+  
 ## Data flow
-
 ```
 src/content/articles/*.md ──glob──> articles collection
         │                                   │
@@ -83,25 +91,31 @@ src/content/articles/*.md ──glob──> articles collection
                      ▼
         dist/insights.md + dist/insights/*.md + sitemap rows
 ```
-
 ## Error / edge handling
 - Empty collection → index empty-state, no broken build.
+  
 - `draft: true` → excluded from index, `getStaticPaths`, and mirrors.
+  
 - Generator: missing `dist/insights/` glob → zero article mirrors, index mirror still emitted (partial-build tolerant, matches existing warn-and-skip behavior).
-
+  
 ## Verification
 - `npm run build` succeeds (Astro build + md-mirror generation).
+  
 - `/insights` lists the seed article; article page renders with correct title/date/JSON-LD.
+  
 - Nav appears site-wide, `aria-current` correct per page, wraps at 360px, keyboard-focusable.
+  
 - Parity oracle / `validate-llms-txt` CI green (or baseline updated intentionally for the new pages).
+  
 - Run the build and inspect `dist/` mirrors myself — do not trust subagent self-reports.
-
+  
 ## Subagents (parallel workers)
 - **A — Nav:** `Header.astro`, `Footer.astro`, header CSS in `global.css` + `BaseLayout` path threading.
+  
 - **B — Hub:** `content.config.ts`, `insights.astro`, `insights/[...slug].astro`, seed article.
-- **C — Pipeline:** `generate-md-mirrors.py`, `llms.txt`, build + parity verification (runs after A & B land).
-A and B touch mostly disjoint files (shared: `global.css`, `BaseLayout`); coordinate those two edits. Main session does final `npm run build` + parity check.
-
-## Out of scope (flagged)
-- Root `CLAUDE.md` staleness (describes legacy root HTML). Fix as housekeeping if approved.
-- Tag/category filtering, RSS, pagination, author pages — deferred (YAGNI until article volume warrants).
+  
+- **C — Pipeline:** `generate-md-mirrors.py`, `llms.txt`, build + parity verification (runs after A & B land). A and B touch mostly disjoint files (shared: `global.css`, `BaseLayout`); coordinate those two edits. Main session does final `npm run build` + parity check.
+  
+## Clean up / Housekeeping
+- Root `CLAUDE.md` staleness (describes legacy root HTML as canonical; live site is Astro in `site/`). Tracked in **[#26](https://github.com/eagle-ridge/Eagle-Ridge/issues/26)** — out of scope for this PR.
+- Tag/category filtering, RSS, pagination, author pages — deferred (YAGNI until article volume warrants). Tracked in **[#27](https://github.com/eagle-ridge/Eagle-Ridge/issues/27)**.

--- a/docs/superpowers/specs/2026-06-12-insights-hub-and-nav-design.md
+++ b/docs/superpowers/specs/2026-06-12-insights-hub-and-nav-design.md
@@ -1,0 +1,107 @@
+# Insights Hub + Header Navigation — Design
+
+**Date:** 2026-06-12
+**Site:** eagleridge.io (Astro static site in `site/`, deployed to Cloudflare Pages)
+**Goal:** Give the site a real header navigation and a content hub ("Insights") where dated articles auto-list from markdown, so a visitor can both *navigate* the site and *learn who Eagle Ridge is* through published thinking.
+
+## Context
+
+- The live site is the Astro rebuild in `site/`. The repo-root `*.html` files are legacy; the root `CLAUDE.md` is stale (still describes hand-written root HTML as canonical).
+- **There is no navigation menu today.** `Header.astro` is a logo lockup + "GRC Readiness" tagline only. Pages are reachable solely via the footer and inline CTAs.
+- An existing `pages` content collection (`src/content.config.ts`, `src/content/pages/*.md`) backs glossary/privacy/essay via thin `.astro` wrappers. There is no *listing* page or blog-style hub.
+- The build runs `scripts/generate-md-mirrors.py`, which emits a `.md` mirror + sitemap entry per page from a **hardcoded `PAGES` list**. It strips `<header>/<footer>/<nav>` and `[data-md-exclude]` from mirrors. A parity oracle (`parity-baseline/`) and a `validate-llms-txt` CI guard against drift.
+
+## Decisions (confirmed with user)
+
+1. **Content hub shape:** Insights hub (blog index) — auto-listing dated articles. (Chosen over a curated resource library: the footer already links evergreen assets, and dated thinking is the trust signal that converts the CEO buyer.)
+2. **Nav contents:** Lean — **About · Insights · Contact**. Market Map / Glossary stay in the footer.
+3. **Seed content:** Author writes the real copy; this work seeds **one short starter article** (flagged for user approval) so the hub launches non-empty.
+
+## Architecture
+
+### 1. Navigation — `src/components/Header.astro`
+- Add `<nav aria-label="Primary">` inside the existing `.site-header` with three links: **About** (`/about`), **Insights** (`/insights`), **Contact** (`/#contact-form`).
+- Brand-consistent styling (IBM Plex Mono, uppercase, small caps tracking) added to `src/styles/global.css`.
+- `aria-current="page"` on the active link — derived from a `currentPath` prop threaded from `BaseLayout` (which already receives `path`).
+- Responsive: three short links wrap cleanly; **no hamburger** (YAGNI for 3 items). Verify wrap behavior at 360px.
+- Mirrors are unaffected — the generator strips `<header>`/`<nav>`.
+
+### 2. Footer — `src/components/Footer.astro`
+- Insert an **Insights** link (after About) for nav/footer parity.
+
+### 3. Content collection — `src/content.config.ts`
+Add an `articles` collection alongside `pages`:
+```ts
+const articles = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/articles' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.date(),
+    updatedDate: z.date().optional(),
+    author: z.string().default('Eagle Ridge Advisory'),
+    draft: z.boolean().default(false),
+    tags: z.array(z.string()).default([]),
+  }),
+});
+export const collections = { pages, articles };
+```
+
+### 4. Insights index — `src/pages/insights.astro`
+- `getCollection('articles')` → filter `!data.draft` → sort by `pubDate` desc.
+- Render a list of article cards: title (links to article), formatted `pubDate`, `description`, "Read →".
+- Empty-state fallback ("New thinking coming soon") if the collection is empty.
+- `BaseLayout` with `path="/insights"`, `title`, `description`; `Blog` JSON-LD in the head slot.
+
+### 5. Article template — `src/pages/insights/[...slug].astro`
+- `getStaticPaths()` over `getCollection('articles')` (drafts excluded), one route per article.
+- `render(entry)` into a `.prose container` `<article>`: H1 title, date byline (+ author), "← Back to Insights".
+- `BaseLayout` with `path={`/insights/${entry.id}`}`; `BlogPosting` JSON-LD (headline, datePublished, dateModified, author).
+
+### 6. Seed article — `src/content/articles/<slug>.md`
+- One ~400-word on-brand starter (working title: "Why readiness comes before the assessment"), plain-language CEO voice, `draft: false`, dated 2026-06-12.
+- Copy flagged in the PR/spec as author-review-pending.
+
+### 7. Build pipeline — `site/scripts/generate-md-mirrors.py`
+- Keep the static `PAGES` list for fixed pages; **append `/insights` and dynamically-discovered `dist/insights/*.html`** so each article auto-gets a `.md` mirror + sitemap row. No per-post edits.
+- Preserve existing extraction/strip logic byte-compatibly (parity oracle).
+
+### 8. `site/public/llms.txt` (or source of it)
+- Add an **Insights** section pointing at `/insights.md` and article `.md` mirrors.
+
+## Data flow
+
+```
+src/content/articles/*.md ──glob──> articles collection
+        │                                   │
+        ├── insights.astro (index) ─────────┤
+        └── insights/[...slug].astro ───────┘
+                     │ astro build
+                     ▼
+        dist/insights.html + dist/insights/*.html
+                     │ generate-md-mirrors.py
+                     ▼
+        dist/insights.md + dist/insights/*.md + sitemap rows
+```
+
+## Error / edge handling
+- Empty collection → index empty-state, no broken build.
+- `draft: true` → excluded from index, `getStaticPaths`, and mirrors.
+- Generator: missing `dist/insights/` glob → zero article mirrors, index mirror still emitted (partial-build tolerant, matches existing warn-and-skip behavior).
+
+## Verification
+- `npm run build` succeeds (Astro build + md-mirror generation).
+- `/insights` lists the seed article; article page renders with correct title/date/JSON-LD.
+- Nav appears site-wide, `aria-current` correct per page, wraps at 360px, keyboard-focusable.
+- Parity oracle / `validate-llms-txt` CI green (or baseline updated intentionally for the new pages).
+- Run the build and inspect `dist/` mirrors myself — do not trust subagent self-reports.
+
+## Subagents (parallel workers)
+- **A — Nav:** `Header.astro`, `Footer.astro`, header CSS in `global.css` + `BaseLayout` path threading.
+- **B — Hub:** `content.config.ts`, `insights.astro`, `insights/[...slug].astro`, seed article.
+- **C — Pipeline:** `generate-md-mirrors.py`, `llms.txt`, build + parity verification (runs after A & B land).
+A and B touch mostly disjoint files (shared: `global.css`, `BaseLayout`); coordinate those two edits. Main session does final `npm run build` + parity check.
+
+## Out of scope (flagged)
+- Root `CLAUDE.md` staleness (describes legacy root HTML). Fix as housekeeping if approved.
+- Tag/category filtering, RSS, pagination, author pages — deferred (YAGNI until article volume warrants).

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -6,6 +6,7 @@
 
 - [Homepage](https://eagleridge.io/index.md): Services overview, compliance frameworks, and contact form
 - [About](https://eagleridge.io/about.md): GRC readiness positioning, who we serve, and consulting approach
+- [Insights](https://eagleridge.io/insights.md): Articles on CMMC and compliance readiness for small-business contractors — new thinking on getting ready before you're assessed
 - [Market Map](https://eagleridge.io/market-map.md): Eagle Ridge's view of the CMMC services market — 89 firms and platforms mapped by category, with the 0→1 readiness gap for DIB SMBs called out
 - [Nobody Built the First Mile](https://eagleridge.io/nobody-built-the-first-mile.md): Long-form argument behind the market map. The structural gap between CMMC assessors and small DIB contractors who need readiness work, and why the window to fix it is closing
 - [Glossary](https://eagleridge.io/glossary.md): Plain-language definitions of CMMC, NIST 800-171, and cybersecurity compliance terms (CUI, FCI, C3PAO, SPRS, POA&M, SSP, DFARS)

--- a/site/scripts/generate-md-mirrors.py
+++ b/site/scripts/generate-md-mirrors.py
@@ -32,6 +32,7 @@ BASE_URL = "https://eagleridge.io"
 PAGES = [
     ("index.html", "/", "Homepage"),
     ("about.html", "/about", "About"),
+    ("insights.html", "/insights", "Insights"),
     ("market-map.html", "/market-map", "Market Map"),
     (
         "nobody-built-the-first-mile.html",
@@ -92,7 +93,9 @@ def write_mirror(html_name: str, public_path: str) -> bool:
     title, body = extract(html)
     url = BASE_URL + public_path
     out = f"<!-- Markdown mirror of {url} -->\n\n# {title}\n\n{body}\n"
-    (DIST / md_name(public_path)).write_text(out, encoding="utf-8")
+    dest = DIST / md_name(public_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(out, encoding="utf-8")
     print(f"  wrote {md_name(public_path)}")
     return True
 
@@ -133,10 +136,29 @@ def write_sitemap_md(built: list[tuple[str, str, str]]) -> None:
     print("  wrote sitemap.md")
 
 
+def discover_insights() -> list[tuple[str, str, str]]:
+    """Discover built Insights article pages under dist/insights/*.html.
+
+    Each article gets a .md mirror + sitemap row automatically — no edits to
+    PAGES per post. Labelled by the page <title> (set by BaseLayout). The
+    /insights index itself is a fixed entry in PAGES.
+    """
+    insights_dir = DIST / "insights"
+    if not insights_dir.is_dir():
+        return []
+    discovered = []
+    for html_file in sorted(insights_dir.glob("*.html")):
+        slug = html_file.stem
+        title, _ = extract(html_file.read_text(encoding="utf-8"))
+        discovered.append((f"insights/{html_file.name}", f"/insights/{slug}", title))
+    return discovered
+
+
 def main() -> None:
     lastmod = dt.date.today().isoformat()
     print("Generating Markdown mirrors:")
-    built = [page for page in PAGES if write_mirror(page[0], page[1])]
+    pages = PAGES + discover_insights()
+    built = [page for page in pages if write_mirror(page[0], page[1])]
     print("Generating sitemaps:")
     write_sitemap_xml(built, lastmod)
     write_sitemap_md(built)

--- a/site/scripts/generate-md-mirrors.py
+++ b/site/scripts/generate-md-mirrors.py
@@ -27,6 +27,10 @@ from markdownify import markdownify
 
 DIST = pathlib.Path(__file__).resolve().parent.parent / "dist"
 BASE_URL = "https://eagleridge.io"
+# Fallback when a page has no <title>. For fixed PAGES this is harmless, but a
+# discovered article should never legitimately be just the site name — see the
+# hard check in discover_insights().
+DEFAULT_TITLE = "Eagle Ridge Advisory"
 
 # (dist html filename, public path, sitemap label). Order = sitemap order.
 PAGES = [
@@ -54,7 +58,7 @@ def extract(html: str) -> tuple[str, str]:
     soup = BeautifulSoup(html, "html.parser")
 
     title_tag = soup.find("title")
-    title = title_tag.get_text(strip=True) if title_tag else "Eagle Ridge Advisory"
+    title = title_tag.get_text(strip=True) if title_tag else DEFAULT_TITLE
 
     for tag in soup.select("[data-md-exclude]"):
         tag.decompose()
@@ -145,12 +149,22 @@ def discover_insights() -> list[tuple[str, str, str]]:
     """
     insights_dir = DIST / "insights"
     if not insights_dir.is_dir():
+        print("  no dist/insights/ — 0 articles discovered")
         return []
     discovered = []
     for html_file in sorted(insights_dir.glob("*.html")):
         slug = html_file.stem
         title, _ = extract(html_file.read_text(encoding="utf-8"))
+        # Discovered articles have no parity baseline backstopping them, so a
+        # blank or fallback title would ship a garbage mirror + sitemap label
+        # with a green CI. Fail loud instead.
+        if not title.strip() or title == DEFAULT_TITLE:
+            raise SystemExit(
+                f"ERROR: dist/insights/{html_file.name} has no usable <title> "
+                f"(got {title!r}) — cannot generate a mirror for it"
+            )
         discovered.append((f"insights/{html_file.name}", f"/insights/{slug}", title))
+    print(f"  discovered {len(discovered)} insights article(s)")
     return discovered
 
 

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -6,6 +6,7 @@
         <p>
             <a href="/">Home</a>
             <a href="/about">About</a>
+            <a href="/insights">Insights</a>
             <a href="/market-map">Market Map</a>
             <a href="/nobody-built-the-first-mile">First Mile</a>
             <a href="/glossary">Glossary</a>

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 // Site masthead per brand kit: mark + uppercase wordmark lockup, mono tagline.
-// Primary nav (About · Insights · Contact) added right of the lockup.
+// Primary nav (About · Insights · Contact) right of the lockup on desktop;
+// collapses to a hamburger + stacked panel at <=720px (see global.css).
 interface Props {
 	currentPath?: string;
 }
@@ -10,6 +11,11 @@ const { currentPath = '' } = Astro.props;
 // article routes (/insights/<slug>). Contact is an in-page anchor, never current.
 const isAbout = currentPath === '/about';
 const isInsights = currentPath === '/insights' || currentPath.startsWith('/insights/');
+const links = [
+	{ href: '/about', label: 'About', current: isAbout },
+	{ href: '/insights', label: 'Insights', current: isInsights },
+	{ href: '/#contact-form', label: 'Contact', current: false },
+];
 ---
 <header class="site-header">
 	<div class="container">
@@ -17,13 +23,61 @@ const isInsights = currentPath === '/insights' || currentPath.startsWith('/insig
 			<img src="/eagle-ridge-mark.png" alt="" width="28" height="28">
 			<span>Eagle Ridge Advisory</span>
 		</a>
+
 		<div class="masthead-right">
 			<nav class="site-nav" aria-label="Primary">
-				<a href="/about" aria-current={isAbout ? 'page' : undefined}>About</a>
-				<a href="/insights" aria-current={isInsights ? 'page' : undefined}>Insights</a>
-				<a href="/#contact-form">Contact</a>
+				{links.map((l) => (
+					<a href={l.href} aria-current={l.current ? 'page' : undefined}>{l.label}</a>
+				))}
 			</nav>
 			<div class="tagline">GRC Readiness</div>
 		</div>
+
+		<button
+			type="button"
+			class="nav-toggle"
+			aria-label="Menu"
+			aria-expanded="false"
+			aria-controls="mobile-nav"
+		>
+			<svg class="icon-menu" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><line x1="4" x2="20" y1="6" y2="6"/><line x1="4" x2="20" y1="12" y2="12"/><line x1="4" x2="20" y1="18" y2="18"/></svg>
+			<svg class="icon-x" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+		</button>
 	</div>
+
+	<nav id="mobile-nav" class="mobile-nav" aria-label="Primary" hidden>
+		{links.map((l) => (
+			<a href={l.href} aria-current={l.current ? 'page' : undefined}>{l.label}</a>
+		))}
+		<span class="mobile-tagline">GRC Readiness</span>
+	</nav>
 </header>
+
+<script>
+	const header = document.currentScript?.closest('.site-header')
+		?? document.querySelector('.site-header');
+	const toggle = header?.querySelector('.nav-toggle') as HTMLButtonElement | null;
+	const panel = header?.querySelector('.mobile-nav') as HTMLElement | null;
+
+	if (toggle && panel) {
+		const setOpen = (open: boolean) => {
+			toggle.setAttribute('aria-expanded', String(open));
+			toggle.classList.toggle('is-open', open);
+			panel.hidden = !open;
+		};
+		toggle.addEventListener('click', () => {
+			setOpen(toggle.getAttribute('aria-expanded') !== 'true');
+		});
+		// Tapping a link closes the panel.
+		panel.querySelectorAll('a').forEach((a) =>
+			a.addEventListener('click', () => setOpen(false))
+		);
+		// Escape closes; crossing back to desktop force-closes.
+		document.addEventListener('keydown', (e) => {
+			if (e.key === 'Escape') setOpen(false);
+		});
+		window.matchMedia('(min-width: 721px)').addEventListener('change', (e) => {
+			if (e.matches) setOpen(false);
+		});
+	}
+</script>

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,12 +1,29 @@
 ---
 // Site masthead per brand kit: mark + uppercase wordmark lockup, mono tagline.
+// Primary nav (About · Insights · Contact) added right of the lockup.
+interface Props {
+	currentPath?: string;
+}
+const { currentPath = '' } = Astro.props;
+
+// aria-current="page" marks the active page link. Insights stays active across
+// article routes (/insights/<slug>). Contact is an in-page anchor, never current.
+const isAbout = currentPath === '/about';
+const isInsights = currentPath === '/insights' || currentPath.startsWith('/insights/');
 ---
 <header class="site-header">
-    <div class="container">
-        <a href="/" class="lockup">
-            <img src="/eagle-ridge-mark.png" alt="" width="28" height="28">
-            <span>Eagle Ridge Advisory</span>
-        </a>
-        <div class="tagline">GRC Readiness</div>
-    </div>
+	<div class="container">
+		<a href="/" class="lockup">
+			<img src="/eagle-ridge-mark.png" alt="" width="28" height="28">
+			<span>Eagle Ridge Advisory</span>
+		</a>
+		<div class="masthead-right">
+			<nav class="site-nav" aria-label="Primary">
+				<a href="/about" aria-current={isAbout ? 'page' : undefined}>About</a>
+				<a href="/insights" aria-current={isInsights ? 'page' : undefined}>Insights</a>
+				<a href="/#contact-form">Contact</a>
+			</nav>
+			<div class="tagline">GRC Readiness</div>
+		</div>
+	</div>
 </header>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -11,4 +11,19 @@ const pages = defineCollection({
   }),
 });
 
-export const collections = { pages };
+// Dated long-form articles, auto-listed by the Insights hub. Each .md lives in
+// src/content/articles/ and renders via src/pages/insights/[...slug].astro.
+const articles = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/articles' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.date(),
+    updatedDate: z.date().optional(),
+    author: z.string().default('Eagle Ridge Advisory'),
+    draft: z.boolean().default(false),
+    tags: z.array(z.string()).default([]),
+  }),
+});
+
+export const collections = { pages, articles };

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -15,15 +15,22 @@ const pages = defineCollection({
 // src/content/articles/ and renders via src/pages/insights/[...slug].astro.
 const articles = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/articles' }),
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    pubDate: z.date(),
-    updatedDate: z.date().optional(),
-    author: z.string().default('Eagle Ridge Advisory'),
-    draft: z.boolean().default(false),
-    tags: z.array(z.string()).default([]),
-  }),
+  schema: z
+    .object({
+      // .min(1): title/description feed <title>, <h1>, meta, OG, and JSON-LD —
+      // an empty string passes z.string() but ships a broken page. Fail loud.
+      title: z.string().min(1),
+      description: z.string().min(1),
+      pubDate: z.date(),
+      updatedDate: z.date().optional(),
+      author: z.string().default('Eagle Ridge Advisory'),
+      draft: z.boolean().default(false),
+      tags: z.array(z.string()).default([]),
+    })
+    .refine((d) => !d.updatedDate || d.updatedDate >= d.pubDate, {
+      message: 'updatedDate must be on or after pubDate',
+      path: ['updatedDate'],
+    }),
 });
 
 export const collections = { pages, articles };

--- a/site/src/content/articles/readiness-before-the-assessment.md
+++ b/site/src/content/articles/readiness-before-the-assessment.md
@@ -1,0 +1,36 @@
+---
+title: "Why Readiness Comes Before the Assessment"
+description: "The firm that gets you ready can't be the one that grades you — so passing your CMMC assessment starts with the work you do before the assessor ever shows up."
+pubDate: 2026-06-12
+draft: false
+tags: ["CMMC", "readiness"]
+---
+
+<!-- DRAFT COPY — pending author (Chris) approval before publish -->
+
+There's a moment every founder hits when a contract they want — or one they already have — suddenly comes with a security requirement attached. A prime asks for proof. A government program names a standard. And the clock starts.
+
+The instinct is to find someone who can "do the assessment." That's the wrong first move, and the rules are written to make sure of it.
+
+## The grader can't also be your coach
+
+The organizations authorized to formally assess you against the standard are held to a strict line: the firm that helps you get ready cannot be the same firm that certifies you. It's the same reason your accountant doesn't audit your own books. Independence is the whole point of the assessment — and it means you need two different relationships, in the right order.
+
+That order matters more than most people expect. The assessment is a snapshot. It measures what's true on the day someone looks. If the work isn't done by then, no amount of goodwill from the assessor changes the result. You don't pass an assessment. You arrive already passing it.
+
+## What "getting ready" actually buys you
+
+Readiness isn't paperwork for its own sake. It's the difference between walking in confident and walking in hoping. Done right, it means:
+
+- You know exactly where you stand before anyone official looks — no surprises.
+- The gaps are closed, not just listed, and you can show how.
+- Your documentation reflects what your company actually does, not a template someone sold you.
+- The person across the table sees a company that runs its security like it runs the rest of the business.
+
+That last point is the quiet advantage. Assessors can tell the difference between a company that bolted things on last week and one that built the habits months ago. The first kind gets questions. The second kind gets through.
+
+## Start upstream
+
+If a contract is pushing you toward certification, the smartest thing you can do is separate the two jobs in your head. There's the assessment — and there's everything that has to be true before it. The second job is the one that decides the outcome, and it's the one a readiness partner exists to do with you.
+
+Get ready first. The assessment is just confirmation of work you've already finished.

--- a/site/src/content/articles/readiness-before-the-assessment.md
+++ b/site/src/content/articles/readiness-before-the-assessment.md
@@ -1,36 +1,34 @@
 ---
 title: "Why Readiness Comes Before the Assessment"
-description: "The firm that gets you ready can't be the one that grades you — so passing your CMMC assessment starts with the work you do before the assessor ever shows up."
+description: "The firm that gets you ready can't be the firm that grades you. Passing your CMMC assessment starts with the work you do before the assessor shows up."
 pubDate: 2026-06-12
 draft: false
 tags: ["CMMC", "readiness"]
 ---
 
-<!-- DRAFT COPY — pending author (Chris) approval before publish -->
+Every founder hits the moment. A contract you want, or one you already have, suddenly carries a security requirement. A prime asks for proof. A government program names a standard. The clock starts.
 
-There's a moment every founder hits when a contract they want — or one they already have — suddenly comes with a security requirement attached. A prime asks for proof. A government program names a standard. And the clock starts.
-
-The instinct is to find someone who can "do the assessment." That's the wrong first move, and the rules are written to make sure of it.
+The instinct is to find someone to "do the assessment." That's the wrong first move, and the rules are written to make sure of it.
 
 ## The grader can't also be your coach
 
-The organizations authorized to formally assess you against the standard are held to a strict line: the firm that helps you get ready cannot be the same firm that certifies you. It's the same reason your accountant doesn't audit your own books. Independence is the whole point of the assessment — and it means you need two different relationships, in the right order.
+The organizations authorized to assess you against the standard follow a strict line: the firm that helps you get ready cannot be the firm that certifies you. It's why your accountant doesn't audit your own books. Independence is the point of an assessment, and it means two separate relationships, in the right order.
 
-That order matters more than most people expect. The assessment is a snapshot. It measures what's true on the day someone looks. If the work isn't done by then, no amount of goodwill from the assessor changes the result. You don't pass an assessment. You arrive already passing it.
+That order matters more than most people expect. An assessment is a snapshot. It measures what's true on the day someone looks. If the work isn't done by then, no amount of goodwill changes the result. You don't pass an assessment. You arrive already passing it.
 
-## What "getting ready" actually buys you
+## What getting ready actually buys you
 
 Readiness isn't paperwork for its own sake. It's the difference between walking in confident and walking in hoping. Done right, it means:
 
-- You know exactly where you stand before anyone official looks — no surprises.
+- You know where you stand before anyone official looks. No surprises.
 - The gaps are closed, not just listed, and you can show how.
 - Your documentation reflects what your company actually does, not a template someone sold you.
-- The person across the table sees a company that runs its security like it runs the rest of the business.
+- The person across the table sees a company that runs security like it runs the rest of the business.
 
-That last point is the quiet advantage. Assessors can tell the difference between a company that bolted things on last week and one that built the habits months ago. The first kind gets questions. The second kind gets through.
+That last point is the quiet advantage. Assessors can tell a company that bolted things on last week from one that built the habits months ago. The first kind gets questions. The second kind gets through.
 
 ## Start upstream
 
-If a contract is pushing you toward certification, the smartest thing you can do is separate the two jobs in your head. There's the assessment — and there's everything that has to be true before it. The second job is the one that decides the outcome, and it's the one a readiness partner exists to do with you.
+If a contract is pushing you toward certification, separate the two jobs in your head. There's the assessment, and there's everything that has to be true before it. The second job decides the outcome. It's the one a readiness partner exists to do with you.
 
-Get ready first. The assessment is just confirmation of work you've already finished.
+Get ready first. The assessment just confirms work you've already finished.

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -56,7 +56,7 @@ const mirror = SITE + (path === '/' ? '/index.md' : `${path}.md`);
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
-    <Header />
+    <Header currentPath={path} />
     <main id="main-content">
         <slot />
     </main>

--- a/site/src/pages/insights.astro
+++ b/site/src/pages/insights.astro
@@ -1,0 +1,185 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const articles = (await getCollection('articles'))
+	.filter((entry) => !entry.data.draft)
+	.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
+
+// timeZone:'UTC' so a date-only pubDate (parsed as UTC midnight) displays as
+// the day the author typed, regardless of the build machine's timezone.
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+	year: 'numeric',
+	month: 'long',
+	day: 'numeric',
+	timeZone: 'UTC',
+});
+const isoDate = (d: Date) => d.toISOString().slice(0, 10);
+
+const jsonLd = JSON.stringify({
+	"@context": "https://schema.org",
+	"@type": "Blog",
+	"name": "Eagle Ridge Advisory Insights",
+	"url": "https://eagleridge.io/insights",
+	"description": "Plain-language thinking on CMMC, SOC 2, and ISO 27001 readiness for small-business CEOs who need to win and keep contracts.",
+	"blogPost": articles.map((entry) => ({
+		"@type": "BlogPosting",
+		"headline": entry.data.title,
+		"description": entry.data.description,
+		"datePublished": isoDate(entry.data.pubDate),
+		"url": `https://eagleridge.io/insights/${entry.id}`,
+	})),
+});
+---
+
+<BaseLayout
+	title="Insights — Eagle Ridge Advisory"
+	description="Plain-language thinking on CMMC, SOC 2, and ISO 27001 readiness for the CEOs who need to win and keep contracts."
+	path="/insights"
+>
+	<Fragment slot="head">
+		<script type="application/ld+json" set:html={jsonLd} />
+	</Fragment>
+
+	<div class="insights container">
+		<header class="insights-head">
+			<p class="er-eyebrow">Insights</p>
+			<h1>New thinking, plainly put.</h1>
+			<p class="er-lede">
+				Readiness, assessments, and the work that wins contracts — written for
+				the founder who has to make the call.
+			</p>
+		</header>
+
+		{articles.length === 0 ? (
+			<div class="empty">
+				<h2>New thinking coming soon</h2>
+				<p>
+					We're putting the finishing touches on our first pieces. Check back
+					shortly — or <a href="/#contact-form">get in touch</a> in the meantime.
+				</p>
+			</div>
+		) : (
+			<ul class="article-list">
+				{articles.map((entry) => (
+					<li class="article-card">
+						<time class="meta" datetime={isoDate(entry.data.pubDate)}>
+							{dateFmt.format(entry.data.pubDate)}
+						</time>
+						<h2 class="card-title">
+							<a href={`/insights/${entry.id}`}>{entry.data.title}</a>
+						</h2>
+						<p class="card-desc">{entry.data.description}</p>
+						<a class="read-more" href={`/insights/${entry.id}`}>
+							Read <span aria-hidden="true">→</span>
+						</a>
+					</li>
+				))}
+			</ul>
+		)}
+	</div>
+</BaseLayout>
+
+<style>
+	.insights {
+		padding: var(--er-space-6) 0 var(--er-space-7);
+	}
+
+	.insights-head {
+		max-width: 52ch;
+		margin-bottom: var(--er-space-6);
+	}
+	.insights-head h1 {
+		font-family: var(--er-font-serif);
+		font-weight: 400;
+		font-size: var(--er-text-h1);
+		line-height: var(--er-leading-tight);
+		letter-spacing: var(--er-tracking-tight);
+		color: var(--er-ink);
+		margin: var(--er-space-2) 0 var(--er-space-3);
+	}
+
+	.article-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		max-width: 72ch;
+	}
+
+	.article-card {
+		padding: var(--er-space-4) 0;
+		border-top: var(--er-border);
+	}
+	.article-card:last-child {
+		border-bottom: var(--er-border);
+	}
+
+	.meta {
+		display: block;
+		font-family: var(--er-font-mono);
+		font-size: var(--er-text-small);
+		letter-spacing: 0;
+		color: var(--er-mute);
+		margin-bottom: var(--er-space-1);
+	}
+
+	.card-title {
+		font-family: var(--er-font-serif);
+		font-weight: 400;
+		font-size: var(--er-text-h3);
+		line-height: 1.2;
+		letter-spacing: var(--er-tracking-tight);
+		margin: 0 0 var(--er-space-1);
+	}
+	.card-title a {
+		color: var(--er-ink);
+		text-decoration: none;
+	}
+	.card-title a:hover {
+		color: var(--er-accent);
+	}
+
+	.card-desc {
+		font-family: var(--er-font-sans);
+		font-size: var(--er-text-body);
+		line-height: var(--er-leading-body);
+		color: var(--er-ink-soft);
+		text-wrap: pretty;
+		margin: 0 0 var(--er-space-2);
+		max-width: 60ch;
+	}
+
+	.read-more {
+		font-family: var(--er-font-mono);
+		font-size: var(--er-text-small);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--er-accent);
+		text-decoration: none;
+	}
+	.read-more:hover {
+		color: var(--er-ink);
+	}
+
+	.empty {
+		max-width: 52ch;
+		padding: var(--er-space-5) 0;
+		border-top: var(--er-border);
+	}
+	.empty h2 {
+		font-family: var(--er-font-serif);
+		font-weight: 400;
+		font-size: var(--er-text-h2);
+		color: var(--er-ink);
+		margin: 0 0 var(--er-space-2);
+	}
+	.empty p {
+		font-family: var(--er-font-sans);
+		font-size: var(--er-text-body);
+		line-height: var(--er-leading-body);
+		color: var(--er-ink-soft);
+	}
+	.empty a {
+		color: var(--er-accent);
+	}
+</style>

--- a/site/src/pages/insights/[...slug].astro
+++ b/site/src/pages/insights/[...slug].astro
@@ -46,7 +46,7 @@ const jsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-	title={entry.data.title}
+	title={`${entry.data.title} — Eagle Ridge Advisory`}
 	description={entry.data.description}
 	path={`/insights/${entry.id}`}
 	ogType="article"
@@ -63,7 +63,7 @@ const jsonLd = JSON.stringify({
 			{entry.data.author}
 		</p>
 		<Content />
-		<p class="back">
+		<p class="back" data-md-exclude>
 			<a href="/insights"><span aria-hidden="true">←</span> Back to Insights</a>
 		</p>
 	</article>

--- a/site/src/pages/insights/[...slug].astro
+++ b/site/src/pages/insights/[...slug].astro
@@ -28,7 +28,34 @@ const isoDate = (d: Date) => d.toISOString().slice(0, 10);
 
 const published = entry.data.pubDate;
 const modified = entry.data.updatedDate ?? entry.data.pubDate;
-const url = `https://eagleridge.io/insights/${entry.id}`;
+const path = `/insights/${entry.id}`;
+const url = `https://eagleridge.io${path}`;
+// The .md twin: generated at build time by scripts/generate-md-mirrors.py
+// (auto-discovers dist/insights/*.html). "Send to LLM" hands over this URL;
+// the in-page markdown view below is a styled preview of the same artifact.
+const mdUrl = `${url}.md`;
+
+// ~200 wpm reading estimate from the raw markdown body.
+const words = entry.body?.trim().split(/\s+/).filter(Boolean).length ?? 0;
+const readingMin = Math.max(1, Math.round(words / 200));
+
+// Light, build-time syntax styling for the markdown preview. Escape first,
+// then wrap headings / links / emphasis — the markdown metacharacters survive
+// HTML-escaping (only & < > are replaced), so the regexes stay safe.
+const esc = (s: string) =>
+	s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const highlightMd = (src: string) =>
+	esc(src)
+		.split('\n')
+		.map((line) => {
+			const h = line.match(/^(#{1,6})\s+(.*)$/);
+			if (h) return `<span class="md-h">${h[1]} </span>${h[2]}`;
+			return line
+				.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<span class="md-link">[$1]($2)</span>')
+				.replace(/\*\*([^*]+)\*\*/g, '<span class="md-strong">**$1**</span>');
+		})
+		.join('\n');
+const mdBody = highlightMd(entry.body ?? '');
 
 const jsonLd = JSON.stringify({
 	"@context": "https://schema.org",
@@ -48,50 +75,337 @@ const jsonLd = JSON.stringify({
 <BaseLayout
 	title={`${entry.data.title} — Eagle Ridge Advisory`}
 	description={entry.data.description}
-	path={`/insights/${entry.id}`}
+	path={path}
 	ogType="article"
 >
 	<Fragment slot="head">
 		<script type="application/ld+json" set:html={jsonLd} />
 	</Fragment>
 
-	<article class="prose container">
+	<article class="prose container article" data-md-url={mdUrl}>
+		<p class="eyebrow-mono">Insights</p>
 		<h1>{entry.data.title}</h1>
-		<p class="byline">
-			<time datetime={isoDate(published)}>{dateFmt.format(published)}</time>
-			<span aria-hidden="true"> · </span>
-			{entry.data.author}
-		</p>
-		<Content />
-		<p class="back" data-md-exclude>
-			<a href="/insights"><span aria-hidden="true">←</span> Back to Insights</a>
-		</p>
+
+		<!-- meta block: byline (tier 1) + AI affordances (tier 2), riding a hairline -->
+		<div class="meta">
+			<p class="byline">By {entry.data.author}<span class="sep"> · </span><time datetime={isoDate(published)}>{dateFmt.format(published)}</time><span class="sep"> · </span>{readingMin} min read</p>
+
+			<div class="controls" data-md-exclude>
+				<button type="button" class="ctl md-toggle" aria-pressed="false">
+					<span class="when-page">
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/></svg>View as Markdown
+					</span>
+					<span class="when-md">
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/></svg>View as page
+					</span>
+				</button>
+
+				<span class="ctl-divider" aria-hidden="true"></span>
+
+				<div class="send">
+					<button type="button" class="ctl send-trigger" aria-haspopup="menu" aria-expanded="false">
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>Send to LLM
+						<svg class="chev" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+					</button>
+					<div class="send-menu" role="menu" aria-label="Open this article in an AI assistant" hidden>
+						<p class="send-menu-label">Open the .md in</p>
+						<button type="button" role="menuitem" data-model="Claude">Claude <span class="tag">.md</span></button>
+						<button type="button" role="menuitem" data-model="ChatGPT">ChatGPT <span class="tag">.md</span></button>
+						<button type="button" role="menuitem" data-model="Gemini">Gemini <span class="tag">.md</span></button>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<p class="sent" hidden data-md-exclude><span class="dot" aria-hidden="true"></span><span class="sent-text"></span></p>
+		<p class="sr-only" aria-live="polite" data-md-exclude></p>
+
+		<!-- page view -->
+		<div class="view view-page">
+			<Content />
+			<p class="back" data-md-exclude>
+				<a href="/insights"><span aria-hidden="true">←</span> Back to Insights</a>
+			</p>
+		</div>
+
+		<!-- markdown view: a styled preview of the .md twin -->
+		<div class="view view-md" data-md-exclude hidden>
+			<div class="md-head">
+				<span class="dot" aria-hidden="true"></span>
+				<span class="md-path">{path}<span class="md-ext">.md</span></span>
+				<span class="md-reads">What the AI reads</span>
+			</div>
+			<div class="md-panel">
+				<div class="md-fence">---</div>
+				<div><span class="md-key">title:</span> {entry.data.title}</div>
+				<div><span class="md-key">date:</span> {isoDate(published)}</div>
+				<div><span class="md-key">author:</span> {entry.data.author}</div>
+				<div><span class="md-key">url:</span> {path}</div>
+				<div class="md-fence">---</div>
+				<pre class="md-content" set:html={mdBody} />
+			</div>
+		</div>
 	</article>
 </BaseLayout>
 
+<script>
+	const article = document.querySelector('.article') as HTMLElement | null;
+	if (article) {
+		const mdUrl = article.dataset.mdUrl ?? '';
+		const toggle = article.querySelector('.md-toggle') as HTMLButtonElement;
+		const pageView = article.querySelector('.view-page') as HTMLElement;
+		const mdView = article.querySelector('.view-md') as HTMLElement;
+		const sendTrigger = article.querySelector('.send-trigger') as HTMLButtonElement;
+		const sendMenu = article.querySelector('.send-menu') as HTMLElement;
+		const sent = article.querySelector('.sent') as HTMLElement;
+		const sentText = article.querySelector('.sent-text') as HTMLElement;
+		const live = article.querySelector('[aria-live]') as HTMLElement;
+
+		// --- view toggle (URL-addressable via ?view=markdown) ---
+		const fade = (el: HTMLElement) => {
+			el.hidden = false;
+			el.classList.remove('fade-in');
+			void el.offsetWidth; // restart the animation
+			el.classList.add('fade-in');
+		};
+		const setView = (md: boolean, pushUrl = true) => {
+			toggle.setAttribute('aria-pressed', String(md));
+			if (md) { pageView.hidden = true; fade(mdView); }
+			else { mdView.hidden = true; fade(pageView); }
+			if (pushUrl) {
+				try {
+					const u = new URL(window.location.href);
+					if (md) u.searchParams.set('view', 'markdown');
+					else u.searchParams.delete('view');
+					history.replaceState({}, '', u);
+				} catch (e) { /* sandboxed iframe: no-op */ }
+			}
+		};
+		toggle.addEventListener('click', () =>
+			setView(toggle.getAttribute('aria-pressed') !== 'true')
+		);
+		// restore from URL on load
+		try {
+			const v = new URLSearchParams(window.location.search).get('view');
+			if (v === 'markdown' || v === 'md') setView(true, false);
+		} catch (e) { /* no-op */ }
+
+		// --- Send to LLM menu ---
+		const openSend = (open: boolean) => {
+			sendTrigger.setAttribute('aria-expanded', String(open));
+			sendMenu.hidden = !open;
+		};
+		sendTrigger.addEventListener('click', (e) => {
+			e.stopPropagation();
+			openSend(sendTrigger.getAttribute('aria-expanded') !== 'true');
+		});
+		document.addEventListener('click', (e) => {
+			if (!sendMenu.hidden && !article.querySelector('.send')!.contains(e.target as Node)) {
+				openSend(false);
+			}
+		});
+		document.addEventListener('keydown', (e) => {
+			if (e.key === 'Escape') openSend(false);
+		});
+
+		let clearTimer: number | undefined;
+		const dest: Record<string, string> = {
+			// Claude and ChatGPT honor ?q= prefill; Gemini's is undocumented —
+			// verify before relying on it (README open decision #3).
+			Claude: 'https://claude.ai/new?q=',
+			ChatGPT: 'https://chatgpt.com/?q=',
+			Gemini: 'https://gemini.google.com/app?q=',
+		};
+		sendMenu.querySelectorAll('[data-model]').forEach((btn) =>
+			btn.addEventListener('click', () => {
+				const model = (btn as HTMLElement).dataset.model!;
+				const q = encodeURIComponent('Please read and summarize this article: ' + mdUrl);
+				try { window.open(dest[model] + q, '_blank', 'noopener,noreferrer'); } catch (e) { /* no-op */ }
+				openSend(false);
+				const file = mdUrl.split('/').pop();
+				sentText.textContent = `Opening ${file} in ${model}…`;
+				sent.hidden = false;
+				live.textContent = `Opening ${file} in ${model}`;
+				clearTimeout(clearTimer);
+				clearTimer = window.setTimeout(() => { sent.hidden = true; live.textContent = ''; }, 2800);
+			})
+		);
+	}
+</script>
+
 <style>
+	.eyebrow-mono {
+		font-family: var(--er-font-mono);
+		font-size: 12px;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: var(--er-accent);
+		margin: 0 0 16px;
+	}
+	.article h1 { margin-bottom: 0; }
+
+	/* ---- meta block (byline + controls, on a hairline) ---- */
+	.meta {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 14px 28px;
+		flex-wrap: wrap;
+		margin: 24px 0 0;
+		padding: 0 0 14px;
+		border-bottom: 1px solid var(--er-rule);
+	}
 	.byline {
 		font-family: var(--er-font-mono);
-		font-size: var(--er-text-small);
-		letter-spacing: 0;
-		color: var(--er-mute);
-		margin: 0 0 var(--er-space-4);
+		font-size: 12px;
+		letter-spacing: 0.06em;
+		color: var(--er-ink-soft);
+		margin: 0;
+		white-space: nowrap;
+	}
+	.byline .sep { color: var(--er-mute); }
+
+	.controls { display: flex; align-items: center; gap: 20px; flex-shrink: 0; }
+	.ctl {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		min-height: 24px;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		cursor: pointer;
+		font-family: var(--er-font-mono);
+		font-size: 11px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--er-ink-soft);
+		white-space: nowrap;
+		transition: color var(--er-dur-fast) var(--er-ease);
+	}
+	.ctl:hover { color: var(--er-accent); }
+	.ctl:focus-visible { outline: 2px solid var(--er-accent); outline-offset: 3px; border-radius: 2px; }
+	.ctl svg { flex-shrink: 0; }
+	.ctl-divider { width: 1px; height: 14px; background: var(--er-rule); flex-shrink: 0; }
+
+	/* label/icon swap driven purely by aria-pressed — no JS needed */
+	.md-toggle .when-page, .md-toggle .when-md { display: inline-flex; align-items: center; gap: 8px; }
+	.md-toggle .when-md { display: none; }
+	.md-toggle[aria-pressed="true"] .when-page { display: none; }
+	.md-toggle[aria-pressed="true"] .when-md { display: inline-flex; }
+
+	/* ---- send menu ---- */
+	.send { position: relative; }
+	.send-menu {
+		position: absolute;
+		top: calc(100% + 10px);
+		right: 0;
+		min-width: 236px;
+		background: var(--er-paper);
+		border: 1px solid var(--er-rule);
+		border-radius: var(--er-radius-md);
+		box-shadow: var(--er-shadow-md);
+		padding: 6px;
+		z-index: 6;
+		animation: er-fade-in var(--er-dur-fast) var(--er-ease);
+	}
+	.send-menu-label {
+		font-family: var(--er-font-mono);
+		font-size: 10px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--er-ink-soft);
+		margin: 4px 13px 6px;
+	}
+	.send-menu [role="menuitem"] {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		width: 100%;
+		min-height: 44px;
+		padding: 0 13px;
+		border: 0;
+		background: transparent;
+		color: var(--er-ink);
+		font-family: var(--er-font-sans);
+		font-size: 14px;
+		text-align: left;
+		cursor: pointer;
+		border-radius: var(--er-radius-sm);
+	}
+	.send-menu [role="menuitem"]:hover,
+	.send-menu [role="menuitem"]:focus-visible {
+		background: var(--surface-sunken);
+		outline: none;
+	}
+	.send-menu [role="menuitem"]:focus-visible { box-shadow: inset 2px 0 0 var(--er-accent); }
+	.send-menu .tag {
+		font-family: var(--er-font-mono);
+		font-size: 10px;
+		letter-spacing: 0.08em;
+		color: var(--er-ink-soft);
+		margin-left: auto;
 	}
 
-	.back {
-		margin-top: var(--er-space-5);
-		padding-top: var(--er-space-3);
-		border-top: var(--er-border);
-	}
-	.back a {
+	/* ---- send confirmation ---- */
+	.sent {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
 		font-family: var(--er-font-mono);
-		font-size: var(--er-text-small);
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--er-accent);
-		text-decoration: none;
+		font-size: 11px;
+		letter-spacing: 0.04em;
+		color: var(--er-ink-soft);
+		margin: 16px 0 0;
 	}
-	.back a:hover {
-		color: var(--er-ink);
+	.dot { width: 7px; height: 7px; border-radius: 50%; background: var(--status-ok); flex-shrink: 0; }
+
+	/* ---- view cross-fade ---- */
+	.view.fade-in { animation: er-fade-in var(--er-dur-base) var(--er-ease); }
+	.view-page { margin-top: 30px; }
+	.view-md { margin-top: 30px; }
+
+	/* ---- markdown preview ---- */
+	.md-head { display: flex; align-items: center; gap: 9px; margin: 0 0 16px; }
+	.md-path {
+		font-family: var(--er-font-mono);
+		font-size: 11px;
+		letter-spacing: 0.08em;
+		color: var(--er-ink-soft);
+	}
+	.md-ext { color: var(--er-accent); }
+	.md-reads {
+		font-family: var(--er-font-mono);
+		font-size: 10px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--er-ink-soft);
+		margin-left: auto;
+	}
+	.md-panel {
+		background: var(--surface-sunken);
+		border: 1px solid var(--er-rule);
+		border-radius: var(--er-radius-md);
+		padding: 24px 26px;
+		font-family: var(--er-font-mono);
+		font-size: 13.5px;
+		line-height: 1.85;
+		color: var(--er-ink-soft);
+		overflow-x: auto;
+	}
+	.md-fence { color: var(--er-gold); }
+	.md-key { color: var(--er-mute); }
+	.md-content {
+		margin: 16px 0 0;
+		font: inherit;
+		white-space: pre-wrap;
+		color: inherit;
+	}
+	.md-content :global(.md-h) { color: var(--er-accent); font-weight: 500; }
+	.md-content :global(.md-link) { color: var(--er-accent); }
+	.md-content :global(.md-strong) { color: var(--er-ink); }
+
+	@media (prefers-reduced-motion: reduce) {
+		.view.fade-in, .send-menu { animation: none; }
 	}
 </style>

--- a/site/src/pages/insights/[...slug].astro
+++ b/site/src/pages/insights/[...slug].astro
@@ -149,17 +149,21 @@ const jsonLd = JSON.stringify({
 </BaseLayout>
 
 <script>
-	const article = document.querySelector('.article') as HTMLElement | null;
-	if (article) {
-		const mdUrl = article.dataset.mdUrl ?? '';
-		const toggle = article.querySelector('.md-toggle') as HTMLButtonElement;
-		const pageView = article.querySelector('.view-page') as HTMLElement;
-		const mdView = article.querySelector('.view-md') as HTMLElement;
-		const sendTrigger = article.querySelector('.send-trigger') as HTMLButtonElement;
-		const sendMenu = article.querySelector('.send-menu') as HTMLElement;
-		const sent = article.querySelector('.sent') as HTMLElement;
-		const sentText = article.querySelector('.sent-text') as HTMLElement;
-		const live = article.querySelector('[aria-live]') as HTMLElement;
+	const article = document.querySelector<HTMLElement>('.article');
+	const mdUrl = article?.dataset.mdUrl ?? '';
+	const toggle = article?.querySelector<HTMLButtonElement>('.md-toggle');
+	const pageView = article?.querySelector<HTMLElement>('.view-page');
+	const mdView = article?.querySelector<HTMLElement>('.view-md');
+	const sendWrap = article?.querySelector<HTMLElement>('.send');
+	const sendTrigger = article?.querySelector<HTMLButtonElement>('.send-trigger');
+	const sendMenu = article?.querySelector<HTMLElement>('.send-menu');
+	const sent = article?.querySelector<HTMLElement>('.sent');
+	const sentText = article?.querySelector<HTMLElement>('.sent-text');
+	const live = article?.querySelector<HTMLElement>('[aria-live]');
+	// Bail loudly (not silently) if any control is missing — the article still reads.
+	if (!toggle || !pageView || !mdView || !sendWrap || !sendTrigger || !sendMenu || !sent || !sentText || !live) {
+		if (article) console.error('[insights] article controls missing — interactive controls disabled');
+	} else {
 
 		// --- view toggle (URL-addressable via ?view=markdown) ---
 		const fade = (el: HTMLElement) => {
@@ -200,34 +204,50 @@ const jsonLd = JSON.stringify({
 			openSend(sendTrigger.getAttribute('aria-expanded') !== 'true');
 		});
 		document.addEventListener('click', (e) => {
-			if (!sendMenu.hidden && !article.querySelector('.send')!.contains(e.target as Node)) {
-				openSend(false);
-			}
+			if (!sendMenu.hidden && !sendWrap.contains(e.target as Node)) openSend(false);
 		});
 		document.addEventListener('keydown', (e) => {
 			if (e.key === 'Escape') openSend(false);
 		});
 
 		let clearTimer: number | undefined;
-		const dest: Record<string, string> = {
-			// Claude and ChatGPT honor ?q= prefill; Gemini's is undocumented —
-			// verify before relying on it (README open decision #3).
+		const notify = (msg: string) => {
+			sentText.textContent = msg;
+			sent.hidden = false;
+			live.textContent = msg;
+			clearTimeout(clearTimer);
+			clearTimer = window.setTimeout(() => { sent.hidden = true; live.textContent = ''; }, 2800);
+		};
+
+		// Claude and ChatGPT honor a ?q= prefill. Gemini has no documented prefill
+		// param, so we copy the prompt to the clipboard and open a blank Gemini.
+		const prefill: Record<'Claude' | 'ChatGPT', string> = {
 			Claude: 'https://claude.ai/new?q=',
 			ChatGPT: 'https://chatgpt.com/?q=',
-			Gemini: 'https://gemini.google.com/app?q=',
 		};
-		sendMenu.querySelectorAll('[data-model]').forEach((btn) =>
-			btn.addEventListener('click', () => {
-				const model = (btn as HTMLElement).dataset.model!;
-				const q = encodeURIComponent('Please read and summarize this article: ' + mdUrl);
-				try { window.open(dest[model] + q, '_blank', 'noopener,noreferrer'); } catch (e) { /* no-op */ }
+		sendMenu.querySelectorAll<HTMLElement>('[data-model]').forEach((btn) =>
+			btn.addEventListener('click', async () => {
+				const model = btn.dataset.model ?? '';
+				const prompt = 'Please read and summarize this article: ' + mdUrl;
+				const file = mdUrl.split('/').pop() || 'the article';
 				openSend(false);
-				const file = mdUrl.split('/').pop();
-				sentText.textContent = `Opening ${file} in ${model}…`;
-				sent.hidden = false;
-				live.textContent = `Opening ${file} in ${model}`;
-				clearTimeout(clearTimer);
-				clearTimer = window.setTimeout(() => { sent.hidden = true; live.textContent = ''; }, 2800);
+
+				if (model === 'Gemini') {
+					try {
+						await navigator.clipboard.writeText(prompt);
+						window.open('https://gemini.google.com/app', '_blank', 'noopener,noreferrer');
+						notify('Prompt copied — paste it into Gemini');
+					} catch {
+						notify(`Couldn't copy — the article is at ${mdUrl}`);
+					}
+					return;
+				}
+
+				const base = prefill[model as 'Claude' | 'ChatGPT'];
+				if (!base) { notify(`Couldn't open ${model} — the article is at ${mdUrl}`); return; }
+				// window.open returns null (it does not throw) when a popup is blocked.
+				const win = window.open(base + encodeURIComponent(prompt), '_blank', 'noopener,noreferrer');
+				notify(win ? `Opening ${file} in ${model}…` : `Popup blocked — the article is at ${mdUrl}`);
 			})
 		);
 	}

--- a/site/src/pages/insights/[...slug].astro
+++ b/site/src/pages/insights/[...slug].astro
@@ -1,0 +1,97 @@
+---
+import { getCollection, render } from 'astro:content';
+import type { GetStaticPaths } from 'astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+export const getStaticPaths = (async () => {
+	const articles = await getCollection('articles');
+	return articles
+		.filter((entry) => !entry.data.draft)
+		.map((entry) => ({
+			params: { slug: entry.id },
+			props: { entry },
+		}));
+}) satisfies GetStaticPaths;
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+
+// timeZone:'UTC' so a date-only pubDate (parsed as UTC midnight) displays as
+// the day the author typed, regardless of the build machine's timezone.
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+	year: 'numeric',
+	month: 'long',
+	day: 'numeric',
+	timeZone: 'UTC',
+});
+const isoDate = (d: Date) => d.toISOString().slice(0, 10);
+
+const published = entry.data.pubDate;
+const modified = entry.data.updatedDate ?? entry.data.pubDate;
+const url = `https://eagleridge.io/insights/${entry.id}`;
+
+const jsonLd = JSON.stringify({
+	"@context": "https://schema.org",
+	"@type": "BlogPosting",
+	"headline": entry.data.title,
+	"description": entry.data.description,
+	"datePublished": isoDate(published),
+	"dateModified": isoDate(modified),
+	"author": {
+		"@type": "Organization",
+		"name": "Eagle Ridge Advisory",
+	},
+	"url": url,
+});
+---
+
+<BaseLayout
+	title={entry.data.title}
+	description={entry.data.description}
+	path={`/insights/${entry.id}`}
+	ogType="article"
+>
+	<Fragment slot="head">
+		<script type="application/ld+json" set:html={jsonLd} />
+	</Fragment>
+
+	<article class="prose container">
+		<h1>{entry.data.title}</h1>
+		<p class="byline">
+			<time datetime={isoDate(published)}>{dateFmt.format(published)}</time>
+			<span aria-hidden="true"> · </span>
+			{entry.data.author}
+		</p>
+		<Content />
+		<p class="back">
+			<a href="/insights"><span aria-hidden="true">←</span> Back to Insights</a>
+		</p>
+	</article>
+</BaseLayout>
+
+<style>
+	.byline {
+		font-family: var(--er-font-mono);
+		font-size: var(--er-text-small);
+		letter-spacing: 0;
+		color: var(--er-mute);
+		margin: 0 0 var(--er-space-4);
+	}
+
+	.back {
+		margin-top: var(--er-space-5);
+		padding-top: var(--er-space-3);
+		border-top: var(--er-border);
+	}
+	.back a {
+		font-family: var(--er-font-mono);
+		font-size: var(--er-text-small);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--er-accent);
+		text-decoration: none;
+	}
+	.back a:hover {
+		color: var(--er-ink);
+	}
+</style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -121,6 +121,7 @@ a { color: var(--er-accent); }
   min-height: 44px;
 }
 .site-nav a:hover { color: var(--er-accent); }
+.site-nav a:focus-visible { outline: 2px solid var(--er-accent); outline-offset: 3px; }
 .site-nav a[aria-current="page"] {
   color: var(--er-accent);
   text-decoration: underline;
@@ -132,12 +133,65 @@ a { color: var(--er-accent); }
   font-size: 12px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--er-mute);
+  /* --er-mute fails WCAG 4.5:1 at this size; ink-soft reads as muted but passes */
+  color: var(--er-ink-soft);
 }
-@media (max-width: 640px) {
-  /* tagline drops; nav owns the right side and may wrap */
-  .site-header .tagline { display: none; }
-  .site-nav { gap: 16px 18px; justify-content: flex-end; }
+
+/* ---- masthead: mobile hamburger (<=720px) ---- */
+.nav-toggle {
+  display: none;
+  width: 44px;
+  height: 44px;
+  margin: -10px -8px -10px 0;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--er-ink);
+  cursor: pointer;
+}
+.nav-toggle:focus-visible { outline: 2px solid var(--er-accent); outline-offset: 2px; }
+.nav-toggle .icon-x { display: none; }
+.nav-toggle.is-open .icon-menu { display: none; }
+.nav-toggle.is-open .icon-x { display: block; }
+
+.mobile-nav {
+  display: none;
+  border-top: 1px solid var(--er-rule);
+  padding: 4px var(--er-gutter) 14px;
+  flex-direction: column;
+  animation: er-fade-in var(--er-dur-fast) var(--er-ease);
+}
+.mobile-nav a,
+.mobile-nav .mobile-tagline {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  font-family: var(--er-font-mono);
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  text-decoration: none;
+  border-bottom: 1px solid var(--er-rule);
+}
+.mobile-nav a { color: var(--er-ink-soft); }
+.mobile-nav a:hover { color: var(--er-accent); }
+.mobile-nav a:focus-visible { outline: 2px solid var(--er-accent); outline-offset: -2px; }
+.mobile-nav a[aria-current="page"] { color: var(--er-accent); }
+.mobile-nav .mobile-tagline { color: var(--er-ink-soft); border-bottom: 0; }
+
+@keyframes er-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mobile-nav { animation: none; }
+}
+
+@media (max-width: 720px) {
+  .masthead-right { display: none; }
+  .nav-toggle { display: inline-flex; }
+  .mobile-nav:not([hidden]) { display: flex; }
 }
 
 .site-footer {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -95,6 +95,38 @@ a { color: var(--er-accent); }
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
+/* lockup left; nav + tagline grouped right */
+.masthead-right {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+}
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 24px;
+}
+.site-nav a {
+  font-family: var(--er-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  /* --er-ink-soft clears WCAG AA (4.5:1) on the header background */
+  color: var(--er-ink-soft);
+  text-decoration: none;
+  /* ~44px tap target without growing the row visually */
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+}
+.site-nav a:hover { color: var(--er-accent); }
+.site-nav a[aria-current="page"] {
+  color: var(--er-accent);
+  text-decoration: underline;
+  text-underline-offset: 5px;
+  text-decoration-thickness: 1.5px;
+}
 .site-header .tagline {
   font-family: var(--er-font-mono);
   font-size: 12px;
@@ -103,7 +135,9 @@ a { color: var(--er-accent); }
   color: var(--er-mute);
 }
 @media (max-width: 640px) {
+  /* tagline drops; nav owns the right side and may wrap */
   .site-header .tagline { display: none; }
+  .site-nav { gap: 16px 18px; justify-content: flex-end; }
 }
 
 .site-footer {

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -63,6 +63,14 @@
   /* ---- Layout ---- */
   --er-maxw: 1200px;
   --er-gutter: clamp(1.25rem, 5vw, 5rem);
+
+  /* ---- Surfaces ---- */
+  --surface-sunken: #EFE9DC;  /* recessed panel — markdown view, code wells */
+
+  /* ---- Motion ---- */
+  --er-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --er-dur-fast: 0.15s;  /* hovers, menus */
+  --er-dur-base: 0.25s;  /* view cross-fade */
 }
 
 /* ---- Theme · Slate (cool, institutional) ---- */


### PR DESCRIPTION
## What

The site had **no navigation menu** — just a logo lockup and tagline. This adds:

1. **Primary header nav** — `About · Insights · Contact` in the masthead, with `aria-current` on the active page. Brand-consistent (mono, uppercase), 44px tap targets, focus-visible, wraps cleanly on mobile (no hamburger needed for 3 links). Insights also added to the footer for parity.
2. **Insights content hub** — a new `/insights` blog index where dated articles auto-list from a new `articles` content collection. Each post is one markdown file → its own page at `/insights/<slug>`. Ships with one seed article.

## How it works

- `articles` collection (`content.config.ts`): `title, description, pubDate, updatedDate?, author, draft, tags`.
- `/insights` index: cards sorted by `pubDate` desc, drafts excluded, empty-state fallback, `Blog` JSON-LD.
- `/insights/[...slug]`: article template with `BlogPosting` JSON-LD, reuses existing `.prose` styling.
- Build pipeline: `generate-md-mirrors.py` now **auto-discovers** `dist/insights/*.html` → `.md` mirrors + sitemap rows. No per-post script edits.
- `llms.txt`: Insights added to Pages.
- Dates formatted with `timeZone: 'UTC'` so a date-only `pubDate` displays the authored day on any build machine (caught + fixed an off-by-one).

## Verification

Ran the same gates as the `validate-llms-txt` CI workflow, locally:
- ✅ `astro build` clean (8 pages, incl. `/insights` + article)
- ✅ **Parity oracle: 0 drift** — all 6 existing mirrors byte-match baseline (nav/footer are stripped from mirrors)
- ✅ Every built page referenced in `llms.txt`; all referenced URLs resolve 200
- ✅ Seed article reviewed by author (economical copy, em-dashes removed)

## Notes

- Built with three parallel subagents (Nav / Hub / Pipeline); the off-by-one date bug and copy were fixed/verified in the main session.
- Housekeeping filed separately: **#26** (root `CLAUDE.md` is stale — still describes legacy root HTML), **#27** (deferred: tag filtering, RSS, pagination, author pages).
- Spec: `docs/superpowers/specs/2026-06-12-insights-hub-and-nav-design.md`.

---

## Update — AI-view affordances + responsive hamburger (commit `4f57e4e`)

Implements the Claude Design **"Navigation"** handoff (`design_handoff_navigation_md/README.md`) — the machine-readable affordances that motivated the hub, plus the masthead treatment the handoff specs. Scoped to the Insights article template.

**Added (4 files, no new dependencies):**

- **`insights/[...slug].astro`** — article meta-block gains two controls:
  - **View as Markdown ⇄ View as page** — URL-addressable via `?view=markdown` (`history.replaceState`), so the markdown view is **shareable** and **restores on reload / back-forward**; cross-fades between views. The markdown view is a **build-time styled preview of the `.md` twin** (YAML frontmatter from `entry.data` + raw body). `data-md-exclude`'d so it never doubles into the generated mirror.
  - **Send to LLM** — menu deep-links **Claude / ChatGPT / Gemini** with the `.md` URL prefilled as a prompt (`?q=`); outside-click + Escape dismiss; transient confirmation mirrored to an `aria-live` region.
- **`Header.astro` + `global.css`** — masthead is now **responsive at ≤720px**: inline nav above, **hamburger (Lucide menu/x) + 48px stacked panel** below; `aria-expanded`, and Escape / link-tap / resize-to-desktop all close it. (Supersedes the "no hamburger needed" note above — the handoff specs one.)
- Icons are **inlined Lucide glyphs** (`code-2, file-text, sparkles, chevron-down, menu, x`) — no astro-icon/font dependency.
- **`tokens.css`** — adds `--surface-sunken` + motion tokens (`--er-ease, --er-dur-fast, --er-dur-base`) the handoff references.
- a11y: focus-visible rings on every new control; `prefers-reduced-motion` disables fades; GRC tagline moved off `--er-mute` (fails WCAG AA at label size) to `--er-ink-soft`.

**Verification:**
- ✅ `astro build` clean
- ✅ `.md` twin mirror stays clean — controls + md-preview excluded, body not duplicated
- ✅ Parity baselines unaffected (only the pre-existing `.html`-vs-clean-URL comment diff)
- ✅ **Playwright drive** confirmed: view toggle flips both ways + writes/clears `?view=markdown`; label swaps; Send menu opens; Escape closes; Claude deep-link correctly encoded; `?view=markdown` restores on load; hamburger shows at 375px with desktop nav hidden, panel opens, link-tap closes.

**Open decisions deferred to product (flagged in the handoff README):**
1. **Gemini `?q=` prefill is undocumented** — shipped as specced (matches prototype); may not pre-populate. Handoff suggests a clipboard fallback. Left with a code comment.
2. The in-page markdown **preview** shows YAML frontmatter while the served `.md` twin (from `generate-md-mirrors.py`) uses an HTML comment + `# title`. Functionally fine but not byte-identical — reconciling means changing the generator + parity baselines (handoff open-decision #1, "confirm"). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
