### PR TITLE
ci: auto-deploy site/ to Cloudflare Pages on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to Cloudflare Pages
+
+# The eagleridge Pages project is a direct-upload project (not git-connected),
+# so this workflow is what makes pushes to main actually deploy. It builds the
+# Astro site in site/ (Node + Python md-mirror generator) and uploads dist/ to
+# the `eagleridge` project via wrangler.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Node dependencies
+        working-directory: site
+        run: npm ci
+
+      - name: Install Python dependencies (pinned — see scripts/requirements.txt)
+        working-directory: site
+        run: python -m pip install -r scripts/requirements.txt
+
+      - name: Build (astro build + md mirrors)
+        working-directory: site
+        run: npm run build
+
+      - name: Deploy dist to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site/dist --project-name eagleridge --branch main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,33 @@
 # Eagle Ridge Advisory — eagleridge.io
 
-Static site hosted on GitHub Pages. Hand-written HTML pages, no build tools. `.nojekyll` disables Jekyll so `.md` mirrors are served raw.
+**Astro site in `site/`, hosted on Cloudflare Pages** (project `eagleridge` → `eagleridge-7z4.pages.dev`). DNS cut over from GitHub Pages on 2026-06-13. The pages/mirrors/tables below describe the **legacy root HTML** site, kept for parity/history; the live site is built from `site/src/`.
 
-## Files
+## Deploy — automated via GitHub Actions
+
+Pushes to `main` that touch `site/**` trigger [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml), which builds the Astro site and uploads `site/dist` to the `eagleridge` Pages project via `wrangler`. **The Pages project is direct-upload, NOT git-connected** — Cloudflare does not rebuild on push by itself; the Action is what deploys. Repo secrets `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` drive it.
+
+### Manual deploy / local repro
+
+```bash
+npm install --prefix site
+env -C site npx astro build
+env -C site uv run --with markdownify==1.2.2 --with beautifulsoup4==4.14.3 \
+  python scripts/generate-md-mirrors.py            # regenerates site/dist/*.md + sitemaps
+# (npm run build does astro build + the generator, but needs the python deps installed)
+
+CF_TOKEN=$(op item get "Dash Cloudflare API Credential" --vault "Developer Vault" --fields credential --reveal)
+CLOUDFLARE_API_TOKEN="$CF_TOKEN" CLOUDFLARE_ACCOUNT_ID=702342b70e150343381e0829834cbcc7 \
+  env -C site npx wrangler pages deploy dist --project-name eagleridge --branch main
+```
+
+### Cloudflare facts
+
+- Account `702342b70e150343381e0829834cbcc7`; zone `eagleridge.io` = `064d7b70f67f32d15f2afbeb10a915f6`.
+- API token: `op://Developer Vault/Dash Cloudflare API Credential/credential` (Zone DNS edit + Pages edit). The older `Cloudflare Worker API` item is Workers-scoped and will NOT work for DNS/Pages.
+- DNS: apex `eagleridge.io` + `www` are proxied CNAMEs → `eagleridge-7z4.pages.dev`. Custom domains are registered on the Pages project; a `deactivated` status means DNS isn't pointing at the project.
+- Legacy GitHub Pages (root HTML / `CNAME` / `.nojekyll`) is retired and no longer served — safe to archive in a follow-up; left in place for now.
+
+## Files (legacy root HTML — historical)
 
 | File | Purpose |
 |------|---------|


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy.yml` so pushes to `main` that touch `site/**` automatically build the Astro site and deploy it to the `eagleridge` Cloudflare Pages project.

## Why

The Pages project is a **direct-upload** project (not git-connected) — confirmed via the CF API (`source: None`, all deployments `ad_hoc`). So pushing to GitHub never rebuilt or deployed the site; deploys were manual `wrangler pages deploy` runs. A recently-pushed prose edit sat undeployed for this reason, and the live domain was still being served by the retired GitHub Pages until today's DNS cutover.

## How it works

- Triggers on push to `main` (paths `site/**`) + `workflow_dispatch`.
- Node 22 + Python 3.12, `npm ci`, `pip install -r site/scripts/requirements.txt` (pinned markdownify/bs4 for parity), `npm run build` (astro build + md-mirror generator).
- `cloudflare/wrangler-action@v3` runs `pages deploy site/dist --project-name eagleridge --branch main`.
- Secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (already set on the repo).

Also updates `CLAUDE.md`, which still described the site as hand-written GitHub Pages HTML — now documents the Astro/Cloudflare Pages setup, the manual deploy command, and the Cloudflare account/zone/token facts.

## Verification

After merge, the push-to-main triggers the workflow; confirm a new deployment appears on the `eagleridge` project and `eagleridge.io` reflects the change. `workflow_dispatch` can also be used to dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)