### PR TITLE
feat(nav): surface reference pages under a "Resources" disclosure

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -11,11 +11,19 @@ const { currentPath = '' } = Astro.props;
 // article routes (/insights/<slug>). Contact is an in-page anchor, never current.
 const isAbout = currentPath === '/about';
 const isInsights = currentPath === '/insights' || currentPath.startsWith('/insights/');
-const links = [
+const primary = [
 	{ href: '/about', label: 'About', current: isAbout },
 	{ href: '/insights', label: 'Insights', current: isInsights },
-	{ href: '/#contact-form', label: 'Contact', current: false },
 ];
+// Reference cluster, grouped under a "Resources" disclosure on desktop and a
+// stacked group on mobile. Exact hrefs → exact-match active state.
+const resources = [
+	{ href: '/market-map', label: 'Market Map' },
+	{ href: '/glossary', label: 'Glossary' },
+	{ href: '/nobody-built-the-first-mile', label: 'First Mile' },
+	{ href: '/compliance-should-just-work', label: 'Manifesto' },
+];
+const isResource = resources.some((r) => r.href === currentPath);
 ---
 <header class="site-header">
 	<div class="container">
@@ -26,9 +34,26 @@ const links = [
 
 		<div class="masthead-right">
 			<nav class="site-nav" aria-label="Primary">
-				{links.map((l) => (
+				{primary.map((l) => (
 					<a href={l.href} aria-current={l.current ? 'page' : undefined}>{l.label}</a>
 				))}
+				<div class="nav-resources-wrap">
+					<button
+						type="button"
+						class:list={['nav-resources', { 'is-active': isResource }]}
+						aria-expanded="false"
+						aria-controls="resources-menu"
+					>
+						Resources
+						<svg class="chev" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+					</button>
+					<div id="resources-menu" class="resources-menu" hidden>
+						{resources.map((r) => (
+							<a href={r.href} aria-current={r.href === currentPath ? 'page' : undefined}>{r.label}</a>
+						))}
+					</div>
+				</div>
+				<a href="/#contact-form">Contact</a>
 			</nav>
 			<div class="tagline">GRC Readiness</div>
 		</div>
@@ -46,9 +71,14 @@ const links = [
 	</div>
 
 	<nav id="mobile-nav" class="mobile-nav" aria-label="Primary" hidden>
-		{links.map((l) => (
+		{primary.map((l) => (
 			<a href={l.href} aria-current={l.current ? 'page' : undefined}>{l.label}</a>
 		))}
+		<span class="mobile-group">Resources</span>
+		{resources.map((r) => (
+			<a href={r.href} aria-current={r.href === currentPath ? 'page' : undefined}>{r.label}</a>
+		))}
+		<a href="/#contact-form">Contact</a>
 		<span class="mobile-tagline">GRC Readiness</span>
 	</nav>
 </header>
@@ -78,6 +108,38 @@ const links = [
 		});
 		window.matchMedia('(min-width: 721px)').addEventListener('change', (e) => {
 			if (e.matches) setOpen(false);
+		});
+	}
+
+	// Desktop "Resources" disclosure (plain button + aria-expanded; NOT role=menu).
+	const resTrigger = header?.querySelector('.nav-resources') as HTMLButtonElement | null;
+	const resWrap = header?.querySelector('.nav-resources-wrap') as HTMLElement | null;
+	const resMenu = header?.querySelector('#resources-menu') as HTMLElement | null;
+
+	if (resTrigger && resWrap && resMenu) {
+		const isOpen = () => resTrigger.getAttribute('aria-expanded') === 'true';
+		const setResOpen = (open: boolean) => {
+			resTrigger.setAttribute('aria-expanded', String(open));
+			resMenu.hidden = !open;
+		};
+		resTrigger.addEventListener('click', () => setResOpen(!isOpen()));
+		// Close on outside-click — test against this disclosure's own wrapper so it
+		// coexists with the other global click handlers on the page.
+		document.addEventListener('click', (e) => {
+			if (isOpen() && !resWrap.contains(e.target as Node)) setResOpen(false);
+		});
+		// Escape closes and returns focus to the trigger — but only when open, so it
+		// doesn't swallow Escape / steal focus when the panel is already closed.
+		document.addEventListener('keydown', (e) => {
+			if (e.key === 'Escape' && isOpen()) {
+				e.preventDefault();
+				setResOpen(false);
+				resTrigger.focus();
+			}
+		});
+		// Crossing to mobile (panel is hidden there) force-closes for clean state.
+		window.matchMedia('(max-width: 720px)').addEventListener('change', (e) => {
+			if (e.matches) setResOpen(false);
 		});
 	}
 </script>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -137,6 +137,62 @@ a { color: var(--er-accent); }
   color: var(--er-ink-soft);
 }
 
+/* ---- desktop "Resources" disclosure ---- */
+.nav-resources-wrap { position: relative; display: inline-flex; }
+.nav-resources {
+  font-family: var(--er-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--er-ink-soft);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 44px;
+}
+.nav-resources:hover { color: var(--er-accent); }
+.nav-resources:focus-visible { outline: 2px solid var(--er-accent); outline-offset: 3px; }
+.nav-resources.is-active {
+  color: var(--er-accent);
+  text-decoration: underline;
+  text-underline-offset: 5px;
+  text-decoration-thickness: 1.5px;
+}
+.nav-resources .chev { transition: transform var(--er-dur-fast) var(--er-ease); }
+.nav-resources[aria-expanded="true"] .chev { transform: rotate(180deg); }
+.resources-menu {
+  position: absolute;
+  top: calc(100% - 4px);
+  right: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  min-width: 184px;
+  padding: 6px 0;
+  background: var(--surface-sunken, var(--er-paper));
+  border: 1px solid var(--er-rule);
+  animation: er-fade-in var(--er-dur-fast) var(--er-ease);
+}
+.resources-menu a {
+  font-family: var(--er-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--er-ink-soft);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 18px;
+}
+.resources-menu a:hover { color: var(--er-accent); }
+.resources-menu a:focus-visible { outline: 2px solid var(--er-accent); outline-offset: -2px; }
+.resources-menu a[aria-current="page"] { color: var(--er-accent); }
+
 /* ---- masthead: mobile hamburger (<=720px) ---- */
 .nav-toggle {
   display: none;
@@ -179,13 +235,27 @@ a { color: var(--er-accent); }
 .mobile-nav a:focus-visible { outline: 2px solid var(--er-accent); outline-offset: -2px; }
 .mobile-nav a[aria-current="page"] { color: var(--er-accent); }
 .mobile-nav .mobile-tagline { color: var(--er-ink-soft); border-bottom: 0; }
+/* Non-interactive group heading above the stacked Resources links. */
+.mobile-nav .mobile-group {
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  padding-top: 10px;
+  font-family: var(--er-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--er-ink-soft);
+}
 
 @keyframes er-fade-in {
   from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: none; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .mobile-nav { animation: none; }
+  .mobile-nav,
+  .resources-menu { animation: none; }
+  .nav-resources .chev { transition: none; }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## What

Header gains a **Resources** disclosure, surfacing the reference cluster that was previously footer-only:

```
About · Insights · Resources ▾ · Contact
```

Dropdown holds **Market Map · Glossary · First Mile · Manifesto**. Footer unchanged.

## How

- **`Header.astro`** — split the single `links` array into `primary` + `resources` + Contact. Desktop renders an **accessible disclosure**: plain `<button>` + `aria-expanded` + `aria-controls` — deliberately **NOT** `role="menu"` / `aria-haspopup` (those imply an arrow-key menu contract we don't implement; see #37). Mobile renders the cluster **stacked** under a non-interactive "Resources" heading (no nested dropdown). Reuses the existing inline Lucide chevron glyph — no new deps.
- **`global.css`** — `.nav-resources` trigger + `.resources-menu` panel + `.mobile-group`, matching existing nav type/spacing tokens; chevron rotates on open; `prefers-reduced-motion` disables the fade + rotation.
- **Active state** — trigger gets `.is-active` on a resource page; the matching inner link gets `aria-current="page"`.

## Verification

Playwright-driven on the built site:
- open/close toggles `aria-expanded` + `hidden`
- **Escape closes AND returns focus to the trigger** (guarded to only-when-open)
- outside-click closes (tests against its own wrapper)
- active states correct on a resource page vs. a non-resource page

`astro build` clean (9 pages). **No `.md` mirror impact** — the generator extracts `<main>` only, so nav text never enters the twins; parity oracle stays green ("Resources" absent from all mirrors; the 5 baseline diffs are the pre-existing `.html`→clean-URL header-comment diffs).

Deploys on merge (touches `site/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)