### PR TITLE
fix(nav): anchor Resources dropdown under its trigger

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -167,7 +167,7 @@ a { color: var(--er-accent); }
 .resources-menu {
   position: absolute;
   top: calc(100% - 4px);
-  right: 0;
+  left: 0;
   z-index: 20;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem

The desktop **Resources** disclosure menu is positioned `right: 0`, so it grows *leftward* from the button — landing under the **Insights** link instead of under **Resources**. It reads as detached/misaligned (see the screenshot the issue was reported with).

## Fix

One line in `site/src/styles/global.css`: `.resources-menu` anchored `left: 0` instead of `right: 0`. Resources sits on the left of a wide nav bar with open space to its right, so the menu now opens directly beneath the trigger and grows rightward — no viewport-overflow risk.

## Verification

- `npm run build --prefix site` succeeds; compiled `dist` CSS confirmed to emit `.resources-menu{...left:0...}`.
- JS behavior (click-toggle, outside-click close, Escape, mobile force-close) unchanged.

_Visual confirm on the deploy preview / after merge — favicon-style browser caching doesn't apply to CSS, so a normal refresh will show it._

🤖 Generated with [Claude Code](https://claude.com/claude-code)