### PR TITLE
feat(site): unlisted /discovery — self-serve Cal.com booking + Web3Forms fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,15 +66,25 @@ CLOUDFLARE_API_TOKEN="$CF_TOKEN" CLOUDFLARE_ACCOUNT_ID=702342b70e150343381e08298
 - **Spam prevention**: Hidden honeypot checkbox (`botcheck`)
 - **Anchor**: `id="contact-form"` for deep links
 
-### Tally.so Discovery Form
-> ⚠️ **Not yet migrated to Astro.** The old `discovery.html` lived only in the legacy root site and was never ported to `site/`. `eagleridge.io/discovery` currently hits the Cloudflare catch-all (serves the homepage), so the intake form is **not live**. To restore it, add `site/src/pages/discovery.astro` with the Tally embed below. Recover the old markup from git history (`git show <pre-2026-06-18>:discovery.html`). Tracked in issue #42.
-- **Page (intended):** `eagleridge.io/discovery` — unlisted (noindex, nofollow), shared via direct URL with clients
-- **Form:** Embedded via Tally iframe with `transparentBackground=1&dynamicHeight=1` params
-- **Form spec:** `eagle-ridge-methodology/clients/nereid-bio/discovery/tally-form-spec.md`
-- **Notion integration:** Tally auto-creates entries in "SSP Intake Responses" database on submission
-- **Tracking event:** `discovery_page_viewed`
-- **To update form:** Edit in Tally UI (tally.so dashboard). The embed code auto-reflects changes.
-- **Free tier note:** "Made with Tally" badge appears. Removable at €25/mo (Tally Pro).
+### Discovery Intake Form (Web3Forms)
+`site/src/pages/discovery.astro` — a minimal first-touch intake landing page. The
+Feb-2026 Tally plan was reversed 2026-06-18 to Web3Forms (same service as the
+contact form); the Tally embed was never built.
+- **Page:** `eagleridge.io/discovery` — unlisted (`noindex, nofollow` via the
+  `BaseLayout` `noindex` prop), shared via direct URL with clients. Not in any nav.
+  Unlisted by convention only — the mirror/sitemap generator's `PAGES` allowlist
+  doesn't include `discovery`, so no `.md` mirror and no sitemap row.
+- **Form:** 3 required fields (name, email, company) + 1 optional ("what are you
+  pursuing?"). Deeper intake is gathered later by a separate enrichment flow, not
+  here. Submits via `fetch()` to `https://api.web3forms.com/submit`, honeypot
+  `botcheck`, stays on page.
+- **Access key:** `3e6cb410-9c3a-4af7-9a6a-dbf012e8d8a1` (shared with the contact
+  form). **Hidden `subject`: "New Discovery Intake — Eagle Ridge"** so intake
+  leads are distinguishable from contact leads in the inbox.
+- **Shared quota:** both forms share the Web3Forms free-tier 250 submissions/month
+  budget. A spam burst on the (leakable) discovery URL can exhaust it and silently
+  drop real leads. Turnstile follow-up tracked separately.
+- **Tracking event:** `discovery_page_viewed` (inline PostHog capture).
 
 ## Audience
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,17 +66,23 @@ CLOUDFLARE_API_TOKEN="$CF_TOKEN" CLOUDFLARE_ACCOUNT_ID=702342b70e150343381e08298
 - **Spam prevention**: Hidden honeypot checkbox (`botcheck`)
 - **Anchor**: `id="contact-form"` for deep links
 
-### Discovery Intake Form (Web3Forms)
-`site/src/pages/discovery.astro` — a minimal first-touch intake landing page. The
-Feb-2026 Tally plan was reversed 2026-06-18 to Web3Forms (same service as the
-contact form); the Tally embed was never built.
+### Discovery Page (Cal.com booking + Web3Forms fallback)
+`site/src/pages/discovery.astro` — an unlisted lead landing page. **Primary action:
+self-serve booking via a Cal.com inline embed; fallback below: a minimal Web3Forms
+intake** for leads not ready to pick a time. The Feb-2026 Tally plan was reversed
+2026-06-18 to Web3Forms (same service as the contact form); the Tally embed was
+never built.
 - **Page:** `eagleridge.io/discovery` — unlisted (`noindex, nofollow` via the
   `BaseLayout` `noindex` prop), shared via direct URL with clients. Not in any nav.
   Unlisted by convention only — the mirror/sitemap generator's `PAGES` allowlist
   doesn't include `discovery`, so no `.md` mirror and no sitemap row.
-- **Form:** 3 required fields (name, email, company) + 1 optional ("what are you
-  pursuing?"). Deeper intake is gathered later by a separate enrichment flow, not
-  here. Submits via `fetch()` to `https://api.web3forms.com/submit`, honeypot
+- **Booking (primary):** Cal.com inline embed (official vanilla snippet, no API/key
+  in page), event `chris-mcconnell/eagle50` (50-min call). Cal collects name/email
+  and sends the invite. A `bookingSuccessful` callback fires a `discovery_call_booked`
+  PostHog event. To change the call, edit the `calLink` in `discovery.astro`.
+- **Form (fallback):** 3 required fields (name, email, company) + 1 optional ("what
+  are you pursuing?"). Deeper intake is gathered later by a separate enrichment flow,
+  not here. Submits via `fetch()` to `https://api.web3forms.com/submit`, honeypot
   `botcheck`, stays on page.
 - **Access key:** `3e6cb410-9c3a-4af7-9a6a-dbf012e8d8a1` (shared with the contact
   form). **Hidden `subject`: "New Discovery Intake — Eagle Ridge"** so intake

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ contact form); the Tally embed was never built.
   leads are distinguishable from contact leads in the inbox.
 - **Shared quota:** both forms share the Web3Forms free-tier 250 submissions/month
   budget. A spam burst on the (leakable) discovery URL can exhaust it and silently
-  drop real leads. Turnstile follow-up tracked separately.
+  drop real leads. Cloudflare Turnstile follow-up: issue #46.
 - **Tracking event:** `discovery_page_viewed` (inline PostHog capture).
 
 ## Audience

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -20,9 +20,10 @@ interface Props {
   description: string;
   path: string; // '/', '/about', ...
   ogType?: string;
+  noindex?: boolean; // unlisted pages: robots noindex + suppress .md mirror link
 }
 
-const { title, description, path, ogType = 'website' } = Astro.props;
+const { title, description, path, ogType = 'website', noindex = false } = Astro.props;
 const SITE = 'https://eagleridge.io';
 const canonical = SITE + (path === '/' ? '/' : path);
 const mirror = SITE + (path === '/' ? '/index.md' : `${path}.md`);
@@ -35,6 +36,7 @@ const mirror = SITE + (path === '/' ? '/index.md' : `${path}.md`);
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{title}</title>
     <meta name="description" content={description}>
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
     <link rel="canonical" href={canonical}>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
@@ -42,7 +44,7 @@ const mirror = SITE + (path === '/' ? '/index.md' : `${path}.md`);
     <meta property="og:url" content={canonical}>
     <meta property="og:title" content={title}>
     <meta property="og:description" content={description}>
-    <link rel="alternate" type="text/markdown" href={mirror}>
+    {!noindex && <link rel="alternate" type="text/markdown" href={mirror} />}
     <slot name="head" />
     <script is:inline>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);

--- a/site/src/pages/discovery.astro
+++ b/site/src/pages/discovery.astro
@@ -1,0 +1,129 @@
+---
+// Unlisted discovery intake page. Minimal first-touch Web3Forms capture
+// (name/email/company + an optional one-liner). The deeper intake data is
+// gathered later by a separate follow-up/enrichment flow, not here.
+// Submit handler is copied from ContactForm.astro and decoupled via its own
+// .discovery-form selector — two Web3Forms surfaces don't justify a shared
+// component yet (revisit at a third).
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Start your discovery | Eagle Ridge Advisory"
+  description="Tell us a little about your company and what you're pursuing. We'll take it from there before your call."
+  path="/discovery"
+  noindex
+>
+  <section class="section">
+    <div class="container">
+      <h1>Let's get you ready.</h1>
+      <p>
+        A few details to start — name, email, and your company. We do the
+        homework before your call, so you don't have to fill out a wall of
+        forms.
+      </p>
+      <form action="https://api.web3forms.com/submit" method="POST" class="discovery-form">
+        <input type="hidden" name="access_key" value="3e6cb410-9c3a-4af7-9a6a-dbf012e8d8a1">
+        <input type="hidden" name="subject" value="New Discovery Intake — Eagle Ridge">
+        <input type="hidden" name="from_name" value="Eagle Ridge Discovery">
+        <div style="display:none"><input type="checkbox" name="botcheck"></div>
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" required aria-required="true" autocomplete="name">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" required aria-required="true" autocomplete="email">
+        <label for="company">Company</label>
+        <input type="text" id="company" name="company" required aria-required="true" autocomplete="organization">
+        <label for="pursuing">What are you pursuing? <span class="optional">(optional)</span></label>
+        <input type="text" id="pursuing" name="pursuing" autocomplete="off" placeholder="e.g. CMMC Level 2, SOC 2, a specific contract">
+        <button type="submit" class="btn">Start discovery</button>
+        <p id="form-status" role="alert" aria-live="polite"></p>
+      </form>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+    .discovery-form {
+        max-width: 560px;
+        text-align: left;
+    }
+    .discovery-form label {
+        display: block;
+        font-family: var(--er-font-mono);
+        font-size: 12px;
+        font-weight: 500;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin-bottom: 6px;
+        /* --er-mute fails WCAG 4.5:1 at label sizes */
+        color: var(--er-ink-soft);
+    }
+    .discovery-form label .optional {
+        text-transform: none;
+        letter-spacing: normal;
+        color: var(--er-mute);
+    }
+    .discovery-form input {
+        width: 100%;
+        padding: 12px 16px;
+        margin-bottom: 20px;
+        border: var(--er-border);
+        border-radius: var(--er-radius-md);
+        background: var(--er-paper);
+        color: var(--er-ink);
+        font-size: 16px;
+        font-family: var(--er-font-sans);
+    }
+    .discovery-form input:focus {
+        outline: 2px solid var(--er-accent);
+        outline-offset: 1px;
+        border-color: var(--er-accent);
+    }
+    #form-status {
+        margin-top: 16px;
+        font-weight: 500;
+    }
+    #form-status.ok { color: var(--status-ok); }
+    #form-status.err { color: var(--status-err); }
+</style>
+
+<script is:inline>
+    (function() {
+        try { posthog.capture('discovery_page_viewed'); } catch (e) {}
+
+        // Discovery form: submit via fetch to keep user on page.
+        var form = document.querySelector('.discovery-form');
+        if (form) {
+            form.addEventListener('submit', function(e) {
+                e.preventDefault();
+                var btn = form.querySelector('button[type="submit"]');
+                var status = document.getElementById('form-status');
+                btn.disabled = true;
+                btn.textContent = 'Sending...';
+                status.textContent = '';
+                status.className = '';
+
+                fetch(form.action, { method: 'POST', body: new FormData(form) })
+                    .then(function(res) { return res.json(); })
+                    .then(function(data) {
+                        if (data.success) {
+                            status.textContent = 'Thanks — we’ll be in touch before your call.';
+                            status.className = 'ok';
+                            form.reset();
+                        } else {
+                            status.textContent = 'Something went wrong. Please email contact@eagleridge.io.';
+                            status.className = 'err';
+                        }
+                    })
+                    .catch(function() {
+                        status.textContent = 'Network error. Please email contact@eagleridge.io.';
+                        status.className = 'err';
+                    })
+                    .finally(function() {
+                        btn.disabled = false;
+                        btn.textContent = 'Start discovery';
+                    });
+            });
+        }
+    })();
+</script>

--- a/site/src/pages/discovery.astro
+++ b/site/src/pages/discovery.astro
@@ -23,8 +23,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         call, so you don't have to fill out a wall of forms.
       </p>
       <!-- ponytail: Cal.com inline embed (vanilla snippet) — self-serve booking
-           with no API/backend. Cal collects name/email and sends the invite. -->
-      <div id="cal-booking" class="cal-embed"></div>
+           with no API/backend. Cal collects name/email and sends the invite.
+           The fallback link shows until the embed reports linkReady (or stays
+           if the third-party script never loads). -->
+      <div id="cal-booking" class="cal-embed">
+        <p id="cal-fallback">Loading available times… <a href="https://cal.com/chris-mcconnell/eagle50">Book here if this doesn't load.</a></p>
+      </div>
 
       <hr class="discovery-rule">
 
@@ -53,9 +57,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <style>
     .cal-embed {
         max-width: 760px;
+        /* loading floor only; the Cal embed self-sizes, so no overflow clip
+           (a clip would nest a scrollbar inside the iframe's own on mobile). */
         min-height: 600px;
         margin-bottom: 48px;
-        overflow: auto;
+    }
+    #cal-fallback {
+        color: var(--er-ink-soft);
+        padding: 16px 0;
     }
     .discovery-rule {
         max-width: 560px;
@@ -117,10 +126,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         calLink: "chris-mcconnell/eagle50",
     });
     Cal.ns.eagle50("ui", { hideEventTypeDetails: false, layout: "month_view" });
+    // Hide the loading/fallback link once the embed is actually up. If the
+    // third-party script never loads, the fallback stays and offers a direct link.
+    Cal.ns.eagle50("on", {
+        action: "linkReady",
+        callback: function () { var f = document.getElementById('cal-fallback'); if (f) f.style.display = 'none'; },
+    });
     // ponytail: forward Cal's booking event to PostHog so we can measure conversion.
+    // sendBeacon so the event survives any navigation Cal triggers after booking.
     Cal.ns.eagle50("on", {
         action: "bookingSuccessful",
-        callback: function () { try { posthog.capture('discovery_call_booked'); } catch (e) {} },
+        callback: function () { try { posthog.capture('discovery_call_booked', {}, { transport: 'sendBeacon' }); } catch (e) {} },
     });
 </script>
 

--- a/site/src/pages/discovery.astro
+++ b/site/src/pages/discovery.astro
@@ -1,7 +1,8 @@
 ---
-// Unlisted discovery intake page. Minimal first-touch Web3Forms capture
-// (name/email/company + an optional one-liner). The deeper intake data is
-// gathered later by a separate follow-up/enrichment flow, not here.
+// Unlisted discovery page. Primary action: self-serve booking via the Cal.com
+// inline embed (event chris-mcconnell/eagle50). Fallback below: the minimal
+// Web3Forms intake for leads who aren't ready to pick a time. The deeper intake
+// data is gathered later by a separate follow-up/enrichment flow, not here.
 // Submit handler is copied from ContactForm.astro and decoupled via its own
 // .discovery-form selector — two Web3Forms surfaces don't justify a shared
 // component yet (revisit at a third).
@@ -9,8 +10,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout
-  title="Start your discovery | Eagle Ridge Advisory"
-  description="Tell us a little about your company and what you're pursuing. We'll take it from there before your call."
+  title="Book your discovery call | Eagle Ridge Advisory"
+  description="Pick a time that works for you, or leave your details and we'll reach out. We do the homework before your call."
   path="/discovery"
   noindex
 >
@@ -18,10 +19,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="container">
       <h1>Let's get you ready.</h1>
       <p>
-        A few details to start — name, email, and your company. We do the
-        homework before your call, so you don't have to fill out a wall of
-        forms.
+        Grab a time that works for you below — we do the homework before your
+        call, so you don't have to fill out a wall of forms.
       </p>
+      <!-- ponytail: Cal.com inline embed (vanilla snippet) — self-serve booking
+           with no API/backend. Cal collects name/email and sends the invite. -->
+      <div id="cal-booking" class="cal-embed"></div>
+
+      <hr class="discovery-rule">
+
+      <h2>Not ready to pick a time?</h2>
+      <p>Leave your details and we'll reach out before your call.</p>
       <form action="https://api.web3forms.com/submit" method="POST" class="discovery-form">
         <input type="hidden" name="access_key" value="3e6cb410-9c3a-4af7-9a6a-dbf012e8d8a1">
         <input type="hidden" name="subject" value="New Discovery Intake — Eagle Ridge">
@@ -35,7 +43,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <input type="text" id="company" name="company" required aria-required="true" autocomplete="organization">
         <label for="pursuing">What are you pursuing? <span class="optional">(optional)</span></label>
         <input type="text" id="pursuing" name="pursuing" autocomplete="off" placeholder="e.g. CMMC Level 2, SOC 2, a specific contract">
-        <button type="submit" class="btn">Start discovery</button>
+        <button type="submit" class="btn">Send details</button>
         <p id="form-status" role="alert" aria-live="polite"></p>
       </form>
     </div>
@@ -43,6 +51,18 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 </BaseLayout>
 
 <style>
+    .cal-embed {
+        max-width: 760px;
+        min-height: 600px;
+        margin-bottom: 48px;
+        overflow: auto;
+    }
+    .discovery-rule {
+        max-width: 560px;
+        margin: 0 0 32px;
+        border: 0;
+        border-top: var(--er-border);
+    }
     .discovery-form {
         max-width: 560px;
         text-align: left;
@@ -87,6 +107,23 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     #form-status.err { color: var(--status-err); }
 </style>
 
+<!-- Cal.com inline embed loader (official vanilla snippet) -->
+<script is:inline>
+    (function (C, A, L) { let p = function (a, ar) { a.q.push(ar); }; let d = C.document; C.Cal = C.Cal || function () { let cal = C.Cal; let ar = arguments; if (!cal.loaded) { cal.ns = {}; cal.q = cal.q || []; d.head.appendChild(d.createElement("script")).src = A; cal.loaded = true; } if (ar[0] === L) { const api = function () { p(api, arguments); }; const namespace = ar[1]; api.q = api.q || []; if (typeof namespace === "string") { cal.ns[namespace] = cal.ns[namespace] || api; p(cal.ns[namespace], ar); p(cal, ["initNamespace", namespace]); } else p(cal, ar); return; } p(cal, ar); }; })(window, "https://app.cal.com/embed/embed.js", "init");
+    Cal("init", "eagle50", { origin: "https://cal.com" });
+    Cal.ns.eagle50("inline", {
+        elementOrSelector: "#cal-booking",
+        config: { layout: "month_view" },
+        calLink: "chris-mcconnell/eagle50",
+    });
+    Cal.ns.eagle50("ui", { hideEventTypeDetails: false, layout: "month_view" });
+    // ponytail: forward Cal's booking event to PostHog so we can measure conversion.
+    Cal.ns.eagle50("on", {
+        action: "bookingSuccessful",
+        callback: function () { try { posthog.capture('discovery_call_booked'); } catch (e) {} },
+    });
+</script>
+
 <script is:inline>
     (function() {
         try { posthog.capture('discovery_page_viewed'); } catch (e) {}
@@ -121,7 +158,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                     })
                     .finally(function() {
                         btn.disabled = false;
-                        btn.textContent = 'Start discovery';
+                        btn.textContent = 'Send details';
                     });
             });
         }


### PR DESCRIPTION
## What

Adds a real, unlisted `/discovery` lead landing page. Until now `/discovery` fell through the Cloudflare Pages catch-all and served the homepage.

**Primary action: self-serve booking** via a Cal.com inline embed (event `chris-mcconnell/eagle50`). **Fallback below:** the minimal Web3Forms intake (name, email, company + optional one-liner) for leads who aren't ready to pick a time. Booking leads with the lowest-friction path; the form still captures everyone else.

Replaces the never-built Tally embed; tooling decision reversed 2026-06-18 to Web3Forms (bead `chrismcconnell-pvvq`).

## Changes

- **`BaseLayout.astro`** — new `noindex?: boolean` prop. Emits `<meta name="robots" content="noindex, nofollow">` **and** suppresses the markdown-mirror `<link rel="alternate">` (the generator never produces `discovery.md`).
- **`discovery.astro`** (new) —
  - Cal.com inline embed (official vanilla snippet, no API, no key in the page). Cal collects name/email and sends the invite. A `bookingSuccessful` callback fires a `discovery_call_booked` PostHog event.
  - Web3Forms form fallback under a "Not ready to pick a time?" heading — reuses ContactForm's submit pattern, decoupled via its own `.discovery-form` selector + distinct subject (`New Discovery Intake — Eagle Ridge`). Success copy does **not** promise a confirmation email.
  - Inline `discovery_page_viewed` PostHog capture.
- **`CLAUDE.md`** — documents the Cal-first layout + the shared Web3Forms 250/mo quota.

Unlisted by convention: not in the generator's `PAGES` allowlist (no `.md` mirror, no sitemap row) and not in nav.

## Verification

- `astro build` + mirror generator clean.
- `discovery.html` has `noindex, nofollow`, the Cal embed script, and `chris-mcconnell/eagle50`; **no** alternate `/discovery.md` link; **no** `dist/discovery.md`; `discovery` absent from `sitemap.xml`. Regression: `about.html` still has its `/about.md` alternate link.
- **In-browser (astro preview):** Cal embed renders live, bookable slots (9:00am–3:00pm shown); form fallback renders below and submits successfully (green status, stays on page, no confirmation-email promise). A test lead was sent to contact@eagleridge.io.

## Follow-ups (separate)

- Cloudflare Turnstile on the Web3Forms form (shared quota is spam-exhaustable) — issue #46.
- Email-confirmation / LLM enrichment flow.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)