### PR TITLE
feat(nav): "Book a call" CTA → Cal.com booking

### DIFF
--- a/docs/recap-2026-06-18-discovery-cal-booking.md
+++ b/docs/recap-2026-06-18-discovery-cal-booking.md
@@ -1,0 +1,51 @@
+# Session Recap: /discovery intake + Cal.com self-serve booking
+
+**Date:** 2026-06-18
+**Project:** Eagle Ridge Advisory (eagleridge.io)
+**PRs:** #45 (open), #48 (open) — both verified, off `main`, no conflicts
+
+## What Was Built
+
+1. **`/discovery` intake page** (PR #45) — replaces the never-built Tally embed.
+   - New `noindex` prop on `BaseLayout.astro`: emits `robots noindex,nofollow` AND
+     suppresses the `.md`-mirror alternate link (the generator never produces
+     `discovery.md`). Unlisted from two directions (prop + generator `PAGES` allowlist).
+   - `discovery.astro`: **book-first** layout — Cal.com inline embed
+     (`chris-mcconnell/eagle50`) primary, minimal Web3Forms intake (name/email/company
+     + optional one-liner) below as a "not ready to pick a time?" fallback. Distinct
+     subject line + `.discovery-form` selector (decoupled copy of ContactForm's handler).
+   - Analytics: `discovery_page_viewed` on load; `discovery_call_booked` on Cal
+     `bookingSuccessful` (sendBeacon transport).
+   - Gilfoyle-reviewed twice → fix-then-ship. Fixes applied: sendBeacon on the booking
+     event, dropped `overflow:auto` (mobile nested-scroll), Cal-failure fallback link.
+
+2. **"Book a call" nav CTA** (PR #48) — filled accent pill in desktop + mobile nav,
+   plain `<a>` to the Cal hosted page (new tab), **zero JS** in the global Header.
+   Beside Contact, not replacing it.
+
+Both verified in-browser (Web3Forms submit → success; Cal embed renders live slots;
+CTA at desktop 1500px + mobile 390px).
+
+## Key Decisions
+
+| Decision | Rationale |
+|---|---|
+| Cal.com **embed/link, not the v2 API** | API is for programmatic booking mgmt we don't have; embed does availability/timezones/booking/invites client-side, no backend, no key in page |
+| **Book-first** layout, form as fallback | Goal is self-serve booking; don't gate it behind a form. Form still captures leads not ready to pick a slot |
+| Nav CTA = **plain link, zero JS** | Robust, no global-header JS cost; easy upgrade to a Cal popup later |
+| `/discovery` stays **unlisted**; CTA points at Cal directly | Keeps the intake page's link-shared role; one Cal event, no duplication |
+
+## Corrections Applied
+
+- AskUserQuestion menu rejected → user wanted "use your smarts to guide me."
+  Codified to feedback memory: when Chris delegates, recommend-and-proceed.
+
+## What's Next
+
+- **Fix #47 first** — Cal event title typo "Eagle **River** Advisory" → "Ridge"
+  (via `@calcom/cli`); now linked from every page via the CTA.
+- Merge #45 + #48 (auto-deploys on push to `main` touching `site/**`); then
+  `curl https://eagleridge.io/discovery`.
+- #49 — verify `discovery_call_booked` fires after a real booking (post-deploy).
+- #46 — Cloudflare Turnstile on the Web3Forms form (shared 250/mo quota).
+- Bead `chrismcconnell-wiei` holds this pick-up context.

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -54,6 +54,7 @@ const isResource = resources.some((r) => r.href === currentPath);
 					</div>
 				</div>
 				<a href="/#contact-form">Contact</a>
+				<a class="nav-cta" href="https://cal.com/chris-mcconnell/eagle50" target="_blank" rel="noopener">Book a call</a>
 			</nav>
 			<div class="tagline">GRC Readiness</div>
 		</div>
@@ -79,6 +80,7 @@ const isResource = resources.some((r) => r.href === currentPath);
 			<a href={r.href} aria-current={r.href === currentPath ? 'page' : undefined}>{r.label}</a>
 		))}
 		<a href="/#contact-form">Contact</a>
+		<a class="nav-cta" href="https://cal.com/chris-mcconnell/eagle50" target="_blank" rel="noopener">Book a call</a>
 		<span class="mobile-tagline">GRC Readiness</span>
 	</nav>
 </header>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -137,6 +137,30 @@ a { color: var(--er-accent); }
   color: var(--er-ink-soft);
 }
 
+/* ---- "Book a call" CTA: filled pill, distinct from the text nav links.
+   Scoped under .site-nav/.mobile-nav so it outranks the generic `a` rules. ---- */
+.site-nav .nav-cta,
+.mobile-nav .nav-cta {
+  color: var(--er-bg);
+  background: var(--er-accent);
+  border: 1px solid var(--er-accent);
+  border-radius: var(--er-radius-md);
+  padding: 8px 16px;
+  text-decoration: none;
+}
+.site-nav .nav-cta:hover,
+.mobile-nav .nav-cta:hover {
+  color: var(--er-bg);
+  background: var(--er-ink);
+  border-color: var(--er-ink);
+}
+.site-nav .nav-cta:focus-visible,
+.mobile-nav .nav-cta:focus-visible {
+  outline: 2px solid var(--er-ink);
+  outline-offset: 3px;
+}
+.mobile-nav .nav-cta { align-self: flex-start; margin-top: 8px; }
+
 /* ---- desktop "Resources" disclosure ---- */
 .nav-resources-wrap { position: relative; display: inline-flex; }
 .nav-resources {


### PR DESCRIPTION
## What

Adds a **"Book a call" CTA** to the site nav (desktop + mobile) — a filled accent pill linking to the Cal.com hosted booking page (`chris-mcconnell/eagle50`, opens in a new tab). Turns the nav's weakest conversion path ("Contact" → scroll to a form) into a real, sitewide self-serve booking entry.

- **Plain link, zero JS** added to the global header (ponytail). Easy upgrade to an in-page Cal popup later.
- **Beside Contact, not replacing it** — Contact (async "email me") and Book (pick a slot) are different intents.
- Distinct from PR #45's unlisted `/discovery` intake page; both point at the same Cal event, no duplication.

## Changes
- `Header.astro` — `.nav-cta` link added after Contact in both the desktop `.site-nav` and the `.mobile-nav` panel.
- `global.css` — `.nav-cta` filled-pill style (accent bg, brand tokens), scoped under `.site-nav`/`.mobile-nav` to outrank the generic nav `a` rules, with hover + `:focus-visible`.

## Verification
- `astro build` clean; CTA present on every built page.
- In-browser: desktop renders the pill between Contact and the GRC Readiness tagline; mobile hamburger panel shows it below Contact. Both verified.

## Related
- Booking event title typo fix tracked in #47 (`@calcom/cli`).
- Discovery intake page: #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)