### PR TITLE
fix(nav): close Resources dropdown when hidden

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -205,6 +205,8 @@ a { color: var(--er-accent); }
   box-shadow: var(--er-shadow-md);
   animation: er-fade-in var(--er-dur-fast) var(--er-ease);
 }
+/* `display: flex` above beats [hidden]'s UA display:none, so it must opt back out. */
+.resources-menu[hidden] { display: none; }
 .resources-menu a {
   font-family: var(--er-font-mono);
   font-size: 12px;


### PR DESCRIPTION
## Problem
The desktop **Resources** nav dropdown rendered permanently open. `.resources-menu { display: flex }` in `global.css` beat the UA `[hidden] { display: none }` rule, so the menu showed regardless of the JS toggle state (`Header.astro` sets `panel.hidden`, but CSS won).

## Fix
One line: `.resources-menu[hidden] { display: none }` — opts the menu back out of display when hidden. Mirrors the existing correct `.mobile-nav:not([hidden]) { display: flex }` guard.

## Verification
- `npx astro build` clean; rule present in built output.
- Local: dropdown closed on load, opens/closes on click + outside-click + Esc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)