### PR TITLE
feat(market-map): table view + sortable columns + per-entity source URLs

### DIFF
--- a/.github/workflows/validate-llms-txt.yml
+++ b/.github/workflows/validate-llms-txt.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Build site (includes mirror + sitemap generation)
         run: npm run build
 
+      - name: Validate entity fields
+        run: npm run check:entities
+
       - name: Check llms.txt exists
         run: |
           if [ ! -f public/llms.txt ]; then

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "users-chrismcconnell-github-eagle-ridge-site",
+  "name": "eagleridge-site",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "users-chrismcconnell-github-eagle-ridge-site",
+      "name": "eagleridge-site",
       "version": "0.0.1",
       "dependencies": {
-        "@fontsource/ibm-plex-mono": "^5.2.7",
-        "@fontsource/ibm-plex-sans": "^5.2.8",
-        "@fontsource/newsreader": "^5.2.10",
-        "astro": "^6.4.5"
+        "@fontsource/ibm-plex-mono": "5.2.7",
+        "@fontsource/ibm-plex-sans": "5.2.8",
+        "@fontsource/newsreader": "5.2.10",
+        "astro": "6.4.5"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,8 @@
     "dev": "astro dev",
     "build": "astro build && python3 scripts/generate-md-mirrors.py",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "check:entities": "node scripts/check-entity-fields.mjs"
   },
   "dependencies": {
     "@fontsource/ibm-plex-mono": "5.2.7",

--- a/site/scripts/check-entity-fields.mjs
+++ b/site/scripts/check-entity-fields.mjs
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const data = JSON.parse(readFileSync(join(__dirname, '../src/data/market-map-entities.json'), 'utf8'));
+
+// Trusted HTML subset: text, HTML entities, <sup>, <a href="#sN"> footnote links
+const HTML_SAFE = /^([^<]|<\/?sup>|<a href="#s\d+">|<\/a>|&[a-z]+;|&#\d+;)*$/;
+let errors = 0;
+
+for (const e of data.entities) {
+  for (const field of ['notes', 'price', 'cmmc', 'target']) {
+    if (!HTML_SAFE.test(e[field] ?? '')) {
+      console.error(`Entity ${e.n} (${e.s}): field "${field}" contains unsafe HTML`);
+      errors++;
+    }
+  }
+  if (e.url && !/^https:\/\//.test(e.url)) {
+    console.error(`Entity ${e.n} (${e.s}): url "${e.url}" is not https://`);
+    errors++;
+  }
+}
+
+if (errors) {
+  console.error(`\n${errors} error(s) found.`);
+  process.exit(1);
+}
+console.log(`✓ All ${data.entities.length} entity fields pass allowlist check`);

--- a/site/scripts/check-entity-fields.mjs
+++ b/site/scripts/check-entity-fields.mjs
@@ -3,21 +3,38 @@ import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const data = JSON.parse(readFileSync(join(__dirname, '../src/data/market-map-entities.json'), 'utf8'));
+
+let data;
+try {
+  data = JSON.parse(readFileSync(join(__dirname, '../src/data/market-map-entities.json'), 'utf8'));
+} catch (err) {
+  console.error(`check-entity-fields: failed to read/parse market-map-entities.json: ${err.message}`);
+  process.exit(1);
+}
 
 // Trusted HTML subset: text, HTML entities, <sup>, <a href="#sN"> footnote links
 const HTML_SAFE = /^([^<]|<\/?sup>|<a href="#s\d+">|<\/a>|&[a-z]+;|&#\d+;)*$/;
+const VALID_CONF = new Set(['high', 'medium', 'low']);
+const VALID_CATS = new Set(Object.keys(data.cats));
 let errors = 0;
 
 for (const e of data.entities) {
   for (const field of ['notes', 'price', 'cmmc', 'target']) {
     if (!HTML_SAFE.test(e[field] ?? '')) {
-      console.error(`Entity ${e.n} (${e.s}): field "${field}" contains unsafe HTML`);
+      console.error(`Entity ${e.n} (${e.s}): field "${field}" contains disallowed characters or markup`);
       errors++;
     }
   }
   if (e.url && !/^https:\/\//.test(e.url)) {
     console.error(`Entity ${e.n} (${e.s}): url "${e.url}" is not https://`);
+    errors++;
+  }
+  if (!VALID_CONF.has(e.conf)) {
+    console.error(`Entity ${e.n} (${e.s}): conf "${e.conf}" is not high/medium/low`);
+    errors++;
+  }
+  if (!VALID_CATS.has(e.cat)) {
+    console.error(`Entity ${e.n} (${e.s}): cat "${e.cat}" is not a known category`);
     errors++;
   }
 }

--- a/site/src/data/market-map-entities.json
+++ b/site/src/data/market-map-entities.json
@@ -92,7 +92,8 @@
    "cmmc": "Authority",
    "price": "N/A",
    "notes": "Accreditation body for the CMMC ecosystem; sets rules for C3PAOs and RPOs<sup><a href=\"#s1\">1</a></sup>. 103 authorized C3PAOs as of Nov 2026<sup><a href=\"#s8\">8</a></sup>.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://cyberab.org"
   },
   {
    "n": 2,
@@ -106,7 +107,8 @@
    "cmmc": "Buyer / issuer",
    "price": "N/A",
    "notes": "Drives CMMC enforcement via 32 CFR (effective Dec 2024) and 48 CFR (effective Nov 2025) clauses now phasing into contracts.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.dodcio.defense.gov/CMMC/"
   },
   {
    "n": 3,
@@ -120,7 +122,8 @@
    "cmmc": "Authority",
    "price": "$30K&ndash;$100K per assessment<sup><a href=\"#s10\">10</a></sup>",
    "notes": "103 authorized C3PAOs<sup><a href=\"#s8\">8</a></sup> serving ~100,000 DIB orgs; ~80,000 of those need Level 2<sup><a href=\"#s9\">9</a></sup>. Only ~1% Level 2 certified to date<sup><a href=\"#s8\">8</a></sup>. The bottleneck. Independence rules: a C3PAO cannot consult on the engagement it assesses.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://cyberab.org/Marketplace"
   },
   {
    "n": 4,
@@ -134,7 +137,8 @@
    "cmmc": "Pre-CMMC authority",
    "price": "N/A",
    "notes": "DCMA's industrial-base assessment arm. Conducted DIBCAC High pre-CMMC; remains relevant for Level 3 and ongoing DoD-direct audits.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.dcma.mil/DIBCAC/"
   },
   {
    "n": 5,
@@ -148,7 +152,8 @@
    "cmmc": "Medium",
    "price": "~$10K&ndash;$30K/yr",
    "notes": "Category leader. Strong SOC 2 muscle; CMMC coverage shipped 2024. Stated focus is SaaS multi-framework rather than DIB-native readiness.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.vanta.com"
   },
   {
    "n": 6,
@@ -162,7 +167,8 @@
    "cmmc": "Medium",
    "price": "~$15K&ndash;$40K/yr",
    "notes": "Close #2 to Vanta. Stronger FedRAMP story and growing CMMC coverage; SaaS-first by DNA.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://drata.com"
   },
   {
    "n": 7,
@@ -176,7 +182,8 @@
    "cmmc": "Low&ndash;medium",
    "price": "~$12K&ndash;$35K/yr",
    "notes": "Strong AI/automation story. Partnered with RSM (C3PAO) for streamlined assessments<sup><a href=\"#s7\">7</a></sup>.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://secureframe.com"
   },
   {
    "n": 8,
@@ -190,7 +197,8 @@
    "cmmc": "Low",
    "price": "~$5K&ndash;$20K/yr",
    "notes": "Lower price point, India-heavy. CMMC not a stated focus.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://sprinto.com"
   },
   {
    "n": 9,
@@ -204,7 +212,8 @@
    "cmmc": "Low",
    "price": "~$10K&ndash;$25K/yr",
    "notes": "Formerly Laika. Bundles audit + automation. CMMC not a primary lane.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://thoropass.com"
   },
   {
    "n": 10,
@@ -218,7 +227,8 @@
    "cmmc": "Buyer",
    "price": "N/A",
    "notes": "80,000+ small contractors expected to need Level 2<sup><a href=\"#s9\">9</a></sup>, below the Tier-1 prime line. The unserved 0&rarr;1 segment Eagle Ridge targets.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.acq.osd.mil/cmmc/"
   },
   {
    "n": 11,
@@ -232,7 +242,8 @@
    "cmmc": "Authority",
    "price": "Varies",
    "notes": "Registered Provider Organizations (~250+). Authorized to advise on CMMC but cannot assess. Natural delivery layer.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://cyberab.org/Marketplace"
   },
   {
    "n": 12,
@@ -246,7 +257,8 @@
    "cmmc": "Authority",
    "price": "N/A",
    "notes": "Registered Practitioners (~5,000+). Individual credential; foundational but rarely sufficient alone.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://cyberab.org/Marketplace"
   },
   {
    "n": 13,
@@ -260,7 +272,8 @@
    "cmmc": "Low&ndash;medium",
    "price": "~$30K+/yr",
    "notes": "Evidence-graph approach. Strong for complex multi-framework; CMMC not native.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.anecdotes.ai"
   },
   {
    "n": 14,
@@ -274,7 +287,8 @@
    "cmmc": "Low&ndash;medium",
    "price": "~$8K&ndash;$25K/yr",
    "notes": "Aggressive on price. CMMC support announced 2024; DIB-specific depth still building.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.scrut.io"
   },
   {
    "n": 15,
@@ -288,7 +302,8 @@
    "cmmc": "Low",
    "price": "Freemium / $5K+",
    "notes": "Freemium model disrupting the price floor. CMMC fit limited.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://trustcloud.ai"
   },
   {
    "n": 16,
@@ -302,7 +317,8 @@
    "cmmc": "Medium",
    "price": "~$10K&ndash;$40K/yr",
    "notes": "Sold through MSSP partners. Decent CMMC coverage; channel-first GTM.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.apptega.com"
   },
   {
    "n": 17,
@@ -316,7 +332,8 @@
    "cmmc": "High",
    "price": "~$20K&ndash;$60K/yr",
    "notes": "Stronger NIST/CMMC alignment than the SaaS-first platforms. Workflow-heavy; better fit for orgs already past 0&rarr;1.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://hyperproof.io"
   },
   {
    "n": 18,
@@ -330,7 +347,8 @@
    "cmmc": "Buyer / enforcer",
    "price": "N/A",
    "notes": "Lockheed, Northrop, RTX, etc. Flowing CMMC requirements down to subs. The demand-creation layer.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.acq.osd.mil/cmmc/"
   },
   {
    "n": 19,
@@ -344,7 +362,8 @@
    "cmmc": "Standard source",
    "price": "N/A",
    "notes": "Sets the standards CMMC enforces. Foundational regulatory authority.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://csrc.nist.gov/pubs/sp/800/171/r3/final"
   },
   {
    "n": 20,
@@ -358,7 +377,8 @@
    "cmmc": "Adjacent",
    "price": "N/A",
    "notes": "DHS cyber arm. Adjacent to CMMC; increasingly relevant for federal supply-chain risk.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.cisa.gov"
   },
   {
    "n": 21,
@@ -372,7 +392,8 @@
    "cmmc": "Medium (via partners)",
    "price": "Enterprise (six&ndash;seven figure annual)",
    "notes": "Enterprise GRC heavyweight. Powerful workflow engine, heavy implementation lift. Not targeted at SMBs.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.servicenow.com/products/governance-risk-compliance.html"
   },
   {
    "n": 22,
@@ -386,7 +407,8 @@
    "cmmc": "Medium",
    "price": "Enterprise",
    "notes": "RSA Archer; legacy GRC. Strong risk management, slower pace of innovation.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.archerirm.com"
   },
   {
    "n": 23,
@@ -400,7 +422,8 @@
    "cmmc": "Medium",
    "price": "Enterprise",
    "notes": "Long-standing enterprise IRM. Broad coverage; not federal/DIB-differentiated.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.metricstream.com"
   },
   {
    "n": 24,
@@ -414,7 +437,8 @@
    "cmmc": "Low&ndash;medium",
    "price": "Enterprise",
    "notes": "Came from privacy; expanded into GRC. Strong data mapping. CMMC not a core lane.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.onetrust.com"
   },
   {
    "n": 25,
@@ -428,7 +452,8 @@
    "cmmc": "Medium",
    "price": "Enterprise",
    "notes": "Modern IRM; more flexible than Archer. Enterprise-priced.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.logicgate.com"
   },
   {
    "n": 26,
@@ -442,7 +467,8 @@
    "cmmc": "Low",
    "price": "Enterprise",
    "notes": "Audit-led platform expanding into GRC. SOX origins; CMMC not a stated focus.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.auditboard.com"
   },
   {
    "n": 27,
@@ -456,7 +482,8 @@
    "cmmc": "None",
    "price": "Enterprise",
    "notes": "Financial reporting / SOX heavyweight. CMMC not in stated scope.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.workiva.com"
   },
   {
    "n": 28,
@@ -470,7 +497,8 @@
    "cmmc": "Low",
    "price": "Enterprise",
    "notes": "Galvanize / HighBond acquisition. Strong board-governance angle.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.diligent.com"
   },
   {
    "n": 29,
@@ -484,7 +512,8 @@
    "cmmc": "Low",
    "price": "Enterprise",
    "notes": "Legacy enterprise GRC. Strong in banking; limited DIB footprint.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.ibm.com/products/openpages-with-watson"
   },
   {
    "n": 30,
@@ -498,7 +527,8 @@
    "cmmc": "None",
    "price": "Enterprise",
    "notes": "Bolted onto SAP installs. DIB SMB is not a stated segment.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.sap.com/products/financial-management/grc.html"
   },
   {
    "n": 31,
@@ -512,7 +542,8 @@
    "cmmc": "High",
    "price": "~$3K&ndash;$15K/yr",
    "notes": "CMMC-native tool. Strong on 110-control mapping; lighter on broader GRC and continuous monitoring.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.futurefeed.co"
   },
   {
    "n": 32,
@@ -526,7 +557,8 @@
    "cmmc": "High",
    "price": "~$1K&ndash;$10K (templates)",
    "notes": "Policy templates (Secure Controls Framework). Document-first, not SaaS. Heavily used by RPOs.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.complianceforge.com"
   },
   {
    "n": 33,
@@ -540,7 +572,8 @@
    "cmmc": "High",
    "price": "~$2K&ndash;$10K/yr",
    "notes": "DIB-focused, SMB-friendly. Strong template library; lighter on continuous monitoring.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.totemtech.com"
   },
   {
    "n": 34,
@@ -554,7 +587,8 @@
    "cmmc": "High",
    "price": "~$5K&ndash;$25K/yr",
    "notes": "Adaptive Risk Model. Stronger on quantification than peers.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://www.cyturus.com"
   },
   {
    "n": 35,
@@ -568,7 +602,8 @@
    "cmmc": "High (supply chain)",
    "price": "Per-license",
    "notes": "DIB identity + supply-chain federation. Mandated by some primes; quasi-infrastructure.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.exostar.com"
   },
   {
    "n": 36,
@@ -582,7 +617,8 @@
    "cmmc": "Buyer",
    "price": "N/A",
    "notes": "Tier 2&ndash;N subcontractors. Where the 0&rarr;1 readiness gap is most acute.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.acq.osd.mil/cmmc/"
   },
   {
    "n": 37,
@@ -596,7 +632,8 @@
    "cmmc": "Oversight",
    "price": "N/A",
    "notes": "Government Accountability Office. Issues critical reports on DoD cybersecurity progress.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.gao.gov"
   },
   {
    "n": 38,
@@ -610,7 +647,8 @@
    "cmmc": "Standards body",
    "price": "Cert fees",
    "notes": "Professional standards body. Frameworks and credentials feed the practitioner layer.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.isaca.org"
   },
   {
    "n": 39,
@@ -625,7 +663,8 @@
    "price": "$5K Full Prep + $1&ndash;1.5K/mo retainer",
    "notes": "Agent-native 0&rarr;1 CMMC readiness for DIB SMBs: SSP draft + SPRS submission; POA&amp;M-to-Conditional path via retainer. Operates in the space between authority frameworks on the left, automation platforms on the right, Big 4 above, and Tier 2 C3PAO/RPOs adjacent. Independent of C3PAO conflict rules. Prepares clients to be assessed by Cherry Bekaert, Aprio, RSM, Baker Tilly, and others. Field-tested on the Nereid Biomaterials engagement at proof-of-concept pricing<sup><a href=\"#s12\">12</a></sup>.",
    "conf": "high",
-   "gap": true
+   "gap": true,
+   "url": "https://eagleridge.io"
   },
   {
    "n": 40,
@@ -639,7 +678,8 @@
    "cmmc": "High (data layer)",
    "price": "Per-seat",
    "notes": "Email/data encryption with strong DIB footprint.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.virtru.com"
   },
   {
    "n": 41,
@@ -653,7 +693,8 @@
    "cmmc": "High",
    "price": "~$25&ndash;$60/user/mo",
    "notes": "End-to-end encrypted email/files for CUI. Strong DIB SMB fit; lighter lift than GCC High.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.preveil.com"
   },
   {
    "n": 42,
@@ -667,7 +708,8 @@
    "cmmc": "High (foundational)",
    "price": "~$30&ndash;$60+/user/mo",
    "notes": "Microsoft Government Community Cloud High. De facto requirement for many DIB contractors handling CUI.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.microsoft.com/en-us/microsoft-365/government/compare-office-365-government-plans"
   },
   {
    "n": 43,
@@ -681,7 +723,8 @@
    "cmmc": "Medium",
    "price": "~$20&ndash;$50/user/mo",
    "notes": "Email security incumbent. CMMC-adjacent via DLP and email controls.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.proofpoint.com"
   },
   {
    "n": 44,
@@ -695,7 +738,8 @@
    "cmmc": "Medium&ndash;high",
    "price": "~$3&ndash;$9/user/mo",
    "notes": "Cisco-owned MFA. Core control for the AC/IA family. Practical CMMC building block.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://duo.com"
   },
   {
    "n": 45,
@@ -709,7 +753,8 @@
    "cmmc": "Adjacent buyer",
    "price": "N/A",
    "notes": "Homeland Security cyber demand. Adjacent ecosystem; future CMMC-like requirements possible.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://www.cisa.gov"
   },
   {
    "n": 46,
@@ -723,7 +768,8 @@
    "cmmc": "Adjacent",
    "price": "Enterprise",
    "notes": "Security-ratings leader. Used by primes to assess subs; outside-in only.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.bitsight.com"
   },
   {
    "n": 47,
@@ -737,7 +783,8 @@
    "cmmc": "Adjacent",
    "price": "Enterprise",
    "notes": "Direct BitSight competitor. Same outside-in model; expanding into questionnaire automation.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://securityscorecard.com"
   },
   {
    "n": 48,
@@ -751,7 +798,8 @@
    "cmmc": "Adjacent",
    "price": "Mid-market",
    "notes": "Combines TPRM with attack-surface management. Mid-market friendly.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.upguard.com"
   },
   {
    "n": 49,
@@ -765,7 +813,8 @@
    "cmmc": "Adjacent",
    "price": "Enterprise",
    "notes": "Questionnaire automation for TPRM. Workflow-heavy.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://www.panorays.com"
   },
   {
    "n": 50,
@@ -779,7 +828,8 @@
    "cmmc": "Adjacent",
    "price": "Enterprise",
    "notes": "Program-led TPRM. Enterprise-focused.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://www.prevalent.net"
   },
   {
    "n": 51,
@@ -793,7 +843,8 @@
    "cmmc": "Adjacent buyer",
    "price": "N/A",
    "notes": "General Services Administration. Civilian contracting hub; FedRAMP authority.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.gsa.gov"
   },
   {
    "n": 52,
@@ -807,7 +858,8 @@
    "cmmc": "None",
    "price": "Enterprise",
    "notes": "Privacy-program-management heritage. Adjacent to but outside the CMMC stack.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://trustarc.com"
   },
   {
    "n": 53,
@@ -821,7 +873,8 @@
    "cmmc": "Low",
    "price": "Enterprise",
    "notes": "Privacy + data-security convergence. Enterprise-focused.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://securiti.ai"
   },
   {
    "n": 54,
@@ -835,7 +888,8 @@
    "cmmc": "Low",
    "price": "Enterprise",
    "notes": "Data discovery and classification. CMMC-adjacent via CUI identification.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://bigid.com"
   },
   {
    "n": 55,
@@ -849,7 +903,8 @@
    "cmmc": "None",
    "price": "Mid-market",
    "notes": "Subject-rights automation. Privacy-focused; CMMC not in stated scope.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://www.datagrail.io"
   },
   {
    "n": 56,
@@ -863,7 +918,8 @@
    "cmmc": "None",
    "price": "Mid-market",
    "notes": "Mid-market privacy. Affordable but narrow.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://www.osano.com"
   },
   {
    "n": 57,
@@ -877,7 +933,8 @@
    "cmmc": "Funding adjacent",
    "price": "N/A",
    "notes": "Small Business Innovation Research / STTR. Funding source for DIB-adjacent innovation.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.sbir.gov"
   },
   {
    "n": 58,
@@ -891,7 +948,8 @@
    "cmmc": "Medium (top-of-market)",
    "price": "Top-of-market",
    "notes": "Big 4 federal practice. Active in CMMC at the prime level; SMB DIB is not the served segment.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www2.deloitte.com/us/en/pages/risk/solutions/cyber-risk-services.html"
   },
   {
    "n": 59,
@@ -905,7 +963,8 @@
    "cmmc": "Medium",
    "price": "Top-of-market",
    "notes": "Big 4. Federal compliance practice; targets large enterprise rather than DIB SMB.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://kpmg.com/us/en/capabilities-services/advisory-services/cyber-security.html"
   },
   {
    "n": 60,
@@ -919,7 +978,8 @@
    "cmmc": "Medium",
    "price": "Top-of-market",
    "notes": "Big 4. Enterprise-focused; DIB SMB readiness is not a stated lane.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.pwc.com/us/en/services/consulting/cybersecurity-risk-regulatory.html"
   },
   {
    "n": 61,
@@ -933,7 +993,8 @@
    "cmmc": "Medium",
    "price": "Top-of-market",
    "notes": "Big 4. Same shape as peers. Top-of-market focus.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.ey.com/en_us/cybersecurity"
   },
   {
    "n": 62,
@@ -947,7 +1008,8 @@
    "cmmc": "High (for primes)",
    "price": "Top-of-market federal",
    "notes": "Largest federal systems integrator. Deep DoD relationships; DIB SMB is not the served segment.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.accenturefederal.com"
   },
   {
    "n": 63,
@@ -961,7 +1023,8 @@
    "cmmc": "High (also C3PAO)",
    "price": "Top-of-market federal",
    "notes": "Defense-native consulting. Also a C3PAO. Stated focus is CMMC strategy work at scale, not SMB readiness delivery.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.boozallen.com/expertise/digital/cybersecurity.html"
   },
   {
    "n": 64,
@@ -975,7 +1038,8 @@
    "cmmc": "High (federal)",
    "price": "Top-of-market federal",
    "notes": "Federal systems integrator. Builds and operates federal systems; SMB advisory not a stated lane.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.leidos.com/capabilities/cybersecurity"
   },
   {
    "n": 65,
@@ -989,7 +1053,8 @@
    "cmmc": "High",
    "price": "Top-of-market federal",
    "notes": "Federal services. Same shape as Leidos.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.saic.com/what-we-do/technology/cybersecurity"
   },
   {
    "n": 66,
@@ -1003,7 +1068,8 @@
    "cmmc": "Medium&ndash;high",
    "price": "Top-of-market federal",
    "notes": "Federal services with strong IC presence.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.caci.com/cybersecurity"
   },
   {
    "n": 67,
@@ -1017,7 +1083,8 @@
    "cmmc": "Medium",
    "price": "Top-of-market",
    "notes": "Federal advisory, spun out of PwC. Compliance-adjacent.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://guidehouse.com/services/advanced-solutions/cybersecurity"
   },
   {
    "n": 68,
@@ -1031,7 +1098,8 @@
    "cmmc": "Medium&ndash;high",
    "price": "Top-of-market federal",
    "notes": "Federal services. Cyber capabilities; not the SMB advisory layer.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.mantech.com/capabilities/cyber"
   },
   {
    "n": 69,
@@ -1045,7 +1113,8 @@
    "cmmc": "Medium",
    "price": "Top-of-market federal",
    "notes": "General Dynamics IT. Federal services prime.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.gdit.com/capabilities/cybersecurity/"
   },
   {
    "n": 82,
@@ -1059,7 +1128,8 @@
    "cmmc": "High (C3PAO + RPO)",
    "price": "$30K&ndash;$100K assessment<sup><a href=\"#s10\">10</a></sup>",
    "notes": "Top 25 US firm. C3PAO since Dec 2022, reauthorized Jan 2025<sup><a href=\"#s2\">2</a></sup>. Aug 2025 Lifeline Data Centers alliance markets &lsquo;CMMC Fasttrack Implementation&rsquo; for SMBs<sup><a href=\"#s3\">3</a></sup>. An explicit move down-market. Among the most structurally complete competitors: C3PAO + RPO + GovCon client base + SMB product motion. Independence rules prevent them from consulting on engagements they assess.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.cbh.com/service/technology-risk-cybersecurity/cmmc/"
   },
   {
    "n": 83,
@@ -1073,7 +1143,8 @@
    "cmmc": "High (C3PAO)",
    "price": "Mid-market advisory",
    "notes": "Top 5 US accounting firm. Authorized C3PAO<sup><a href=\"#s7\">7</a></sup>. Secureframe partner enabling streamlined assessments. Broad risk advisory practice with global reach; CMMC is one of many compliance offerings.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://rsmus.com/services/risk-advisory/technology-risk/cmmc.html"
   },
   {
    "n": 84,
@@ -1087,7 +1158,8 @@
    "cmmc": "High (C3PAO)",
    "price": "Mid-market advisory",
    "notes": "Top 10 US firm formed by 2024 FORVIS-Mazars merger. Authorized C3PAO<sup><a href=\"#s7\">7</a></sup>. International reach via Mazars network.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.forvismazars.com/us/en/services/assurance/cybersecurity-and-cmmc"
   },
   {
    "n": 85,
@@ -1101,7 +1173,8 @@
    "cmmc": "High (C3PAO)",
    "price": "Mid-market advisory",
    "notes": "Mid-sized US firm. CMMC offered as a component of government services and risk advisory practice<sup><a href=\"#s7\">7</a></sup>. Less marketing surface than peers but in the C3PAO pool.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.horne-llp.com/services/government-services/cmmc/"
   },
   {
    "n": 86,
@@ -1115,7 +1188,8 @@
    "cmmc": "High (C3PAO + 3PAO dual)",
    "price": "Mid-market advisory",
    "notes": "Top 25 US firm. C3PAO + FedRAMP 3PAO since June 2025<sup><a href=\"#s4\">4</a></sup>. One of only ~12 firms with both designations. Markets as &lsquo;audit partner not just assessor.&rsquo; Strong PNW + tech sector presence. Built proprietary CMMC Accelerator for gap analysis.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.aprio.com/services/risk-advisory/cmmc/"
   },
   {
    "n": 87,
@@ -1129,7 +1203,8 @@
    "cmmc": "High (C3PAO via subsidiary)",
    "price": "Mid-market advisory",
    "notes": "Top 10 US firm. C3PAO since April 2021 via Baker Tilly Data Systems (now Baker Tilly Beers &amp; Cutler, LLC)<sup><a href=\"#s5\">5</a></sup>. Matt Gilbert (CMMC Leader) was one of the first 100 provisional assessors. 800+ self-reported GovCon clients. Likely the largest installed base in this tier.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.bakertilly.com/specializations/cmmc"
   },
   {
    "n": 88,
@@ -1143,12 +1218,13 @@
    "cmmc": "High (C3PAO)",
    "price": "Regional advisory",
    "notes": "Top 60 US CPA firm. C3PAO since Feb 2025<sup><a href=\"#s6\">6</a></sup>. Among the first 54 nationwide authorizations. Regional focus on PA/OH/WV/NY/MD/DC. CCPs and CCAs in-house.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://schneiderdowns.com/our-services/cybersecurity/cmmc-consulting/"
   },
   {
    "n": 89,
    "s": "Sh",
-   "name": "SC&amp;H Group",
+   "name": "SC&H Group",
    "cat": "tier2",
    "row": 9,
    "col": 11,
@@ -1157,7 +1233,8 @@
    "cmmc": "Adjacent (no C3PAO)",
    "price": "Mid-market advisory",
    "notes": "Mid-market advisory firm; 450+ employees, MD-HQ. Government Contracting is a named industry vertical. Cyber sits inside Risk practice but no C3PAO designation is visible in public materials<sup><a href=\"#s11\">11</a></sup>. Surfaces CMMC adjacent to existing client relationships rather than as a lead offering. Likely RPO-track.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.schgroup.com/services/risk/cybersecurity-advisory-assessment/"
   },
   {
    "n": 70,
@@ -1171,7 +1248,8 @@
    "cmmc": "High",
    "price": "Boutique advisory",
    "notes": "Microsoft-aligned CMMC specialist. Strong GCC High implementation footprint.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.summit7.us"
   },
   {
    "n": 71,
@@ -1185,7 +1263,8 @@
    "cmmc": "High",
    "price": "Boutique advisory",
    "notes": "DIB-native consulting + managed services. One of the more visible CMMC RPOs.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://cybersheath.com"
   },
   {
    "n": 72,
@@ -1199,7 +1278,8 @@
    "cmmc": "High",
    "price": "Boutique advisory",
    "notes": "DIB SMB advisory with GovCon ERP heritage (Deltek). Strong vertical fit.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://neosystemscorp.com"
   },
   {
    "n": 73,
@@ -1213,7 +1293,8 @@
    "cmmc": "High (also C3PAO)",
    "price": "$15K&ndash;$75K/assessment",
    "notes": "Among the first authorized C3PAOs (June 2021). Bridges consulting + assessment.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.redspin.com"
   },
   {
    "n": 74,
@@ -1227,7 +1308,8 @@
    "cmmc": "Medium",
    "price": "Boutique advisory",
    "notes": "Mixed healthcare/DIB compliance. Generalist boutique.",
-   "conf": "low"
+   "conf": "low",
+   "url": "https://etactics.com"
   },
   {
    "n": 75,
@@ -1241,7 +1323,8 @@
    "cmmc": "High (also C3PAO)",
    "price": "Specialty advisory",
    "notes": "Larger specialty firm; strong FedRAMP/3PAO presence. Coalfire Federal authorized as C3PAO Jan 2025. Above the SMB price point.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.coalfire.com"
   },
   {
    "n": 76,
@@ -1255,7 +1338,8 @@
    "cmmc": "Medium&ndash;high (C3PAO)",
    "price": "Specialty advisory",
    "notes": "Audit firm with strong assurance practice. C3PAO. Mid-large oriented rather than SMB.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.schellman.com"
   },
   {
    "n": 77,
@@ -1269,7 +1353,8 @@
    "cmmc": "Medium (controls support)",
    "price": "Mid-market MDR",
    "notes": "Concierge MDR. Supports detection controls; not GRC-native.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://arcticwolf.com"
   },
   {
    "n": 78,
@@ -1283,7 +1368,8 @@
    "cmmc": "Medium",
    "price": "Per-endpoint",
    "notes": "EDR/XDR leader. Controls-layer foundational, not GRC delivery.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.crowdstrike.com"
   },
   {
    "n": 79,
@@ -1297,7 +1383,8 @@
    "cmmc": "Low&ndash;medium",
    "price": "Mid-market MSSP",
    "notes": "Long-running MSSP. Diversified; CMMC not a stated lead.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.trustwave.com"
   },
   {
    "n": 80,
@@ -1311,7 +1398,8 @@
    "cmmc": "Medium",
    "price": "Mid-market MDR",
    "notes": "Vulnerability management + MDR. Adjacent to CMMC controls layer.",
-   "conf": "high"
+   "conf": "high",
+   "url": "https://www.rapid7.com"
   },
   {
    "n": 81,
@@ -1325,7 +1413,8 @@
    "cmmc": "Medium",
    "price": "Varies",
    "notes": "Mega-reseller + services. Channel for many GRC products; mixed advisory layer.",
-   "conf": "medium"
+   "conf": "medium",
+   "url": "https://www.optiv.com"
   }
  ]
 }

--- a/site/src/pages/market-map.astro
+++ b/site/src/pages/market-map.astro
@@ -54,7 +54,7 @@ const jsonLd = JSON.stringify({
   <Fragment slot="head">
     <script type="application/ld+json" set:html={jsonLd} />
     <meta property="og:image" content="https://eagleridge.io/logo.png">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.4.0/dist/tabler-icons.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.4.0/dist/tabler-icons.min.css" integrity="sha384-ldmpcx1x0Xzlz3FRdxRDXdddHL6gUAnUo8m6ERvU0MbQIl53rnzI7hCF+Fd8lRsX" crossorigin="anonymous">
   </Fragment>
 
   <div class="map-body">
@@ -164,7 +164,7 @@ const jsonLd = JSON.stringify({
                   <td set:html={e.cmmc} />
                   <td set:html={e.price} />
                   <td>
-                    {e.url && e.url.startsWith('https://') ? (
+                    {e.url && /^https:\/\//.test(e.url) ? (
                       <a href={e.url} target="_blank" rel="noopener noreferrer" class="source-link" onclick="event.stopPropagation()">↗</a>
                     ) : <span>—</span>}
                   </td>
@@ -630,6 +630,7 @@ const jsonLd = JSON.stringify({
       node.addEventListener('click', () => {
         const e = E.find((x) => x.n === Number(node.dataset.num));
         if (e) showDetail(e);
+        else console.warn('market-map: no entity for data-num', node.dataset.num);
       });
     });
 
@@ -682,7 +683,9 @@ const jsonLd = JSON.stringify({
 
     tableHeaders.forEach((th) => {
       th.addEventListener('click', () => {
-        const col = th.dataset.col!;
+        if (!tableBody) return;
+        const col = th.dataset.col;
+        if (!col) return;
         if (sortCol === col) {
           if (sortDir === 'asc') {
             sortDir = 'desc';
@@ -699,13 +702,11 @@ const jsonLd = JSON.stringify({
         }
         tableHeaders.forEach((h) => h.setAttribute('aria-sort', 'none'));
         th.setAttribute('aria-sort', sortDir === 'asc' ? 'ascending' : 'descending');
-
-        if (!tableBody) return;
         const rows = Array.from(tableBody.querySelectorAll<HTMLElement>('.table-row'));
         rows.sort((a, b) => {
           const av = (a.dataset[col] ?? '');
           const bv = (b.dataset[col] ?? '');
-          return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+          return sortDir === 'asc' ? av.localeCompare(bv, 'en', { sensitivity: 'base' }) : bv.localeCompare(av, 'en', { sensitivity: 'base' });
         });
         rows.forEach((r) => tableBody.appendChild(r));
       });
@@ -742,7 +743,7 @@ const jsonLd = JSON.stringify({
     if (viewToggle && mapBody) {
       viewToggle.addEventListener('click', () => {
         const isTable = mapBody.dataset.view === 'table';
-        mapBody.dataset.view = isTable ? '' : 'table';
+        if (isTable) delete mapBody.dataset.view; else mapBody.dataset.view = 'table';
         viewToggle.setAttribute('aria-pressed', String(!isTable));
         viewToggle.textContent = isTable ? 'Table view' : 'Grid view';
       });

--- a/site/src/pages/market-map.astro
+++ b/site/src/pages/market-map.astro
@@ -15,7 +15,7 @@ const CATS = data.cats as Record<string, { label: string; fill: string; text: st
 const E = data.entities as Array<{
   n: number; s: string; name: string; cat: string; row: number; col: number;
   target: string; fw: string; cmmc: string; price: string; notes: string;
-  conf: string; gap?: boolean;
+  conf: string; gap?: boolean; url?: string;
 }>;
 
 const mainEls = E.filter((e) => e.row <= 7);
@@ -75,6 +75,7 @@ const jsonLd = JSON.stringify({
 
       <div class="controls">
         <input type="text" id="search" placeholder="Search by name or symbol...">
+        <button id="view-toggle" type="button" aria-pressed="false">Table view</button>
         <button id="reset" type="button">Reset</button>
       </div>
 
@@ -127,6 +128,53 @@ const jsonLd = JSON.stringify({
         ))}
       </div>
 
+      <!-- Table view: build-time rendered, hidden by default, shown via JS toggle -->
+      <div class="table-view" id="table-view" data-md-exclude>
+        <table class="entity-table">
+          <thead>
+            <tr>
+              <th data-col="name" aria-sort="none" tabindex="0">Name <span class="sort-icon">↕</span></th>
+              <th data-col="cat" aria-sort="none" tabindex="0">Category <span class="sort-icon">↕</span></th>
+              <th data-col="cmmc" aria-sort="none" tabindex="0">CMMC L2 fit <span class="sort-icon">↕</span></th>
+              <th data-col="price" aria-sort="none" tabindex="0">Pricing <span class="sort-icon">↕</span></th>
+              <th>Source</th>
+            </tr>
+          </thead>
+          <tbody>
+            {E.map((e) => {
+              const c = CATS[e.cat];
+              // Strip HTML for sort keys
+              const cmmcText = e.cmmc.replace(/<[^>]+>/g, '').replace(/&[a-z]+;/g, '');
+              const priceText = e.price.replace(/<[^>]+>/g, '').replace(/&[a-z]+;/g, '');
+              return (
+                <tr
+                  class={'table-row' + (e.gap ? ' gap' : '')}
+                  data-num={e.n}
+                  data-name={e.name.toLowerCase()}
+                  data-cat={CATS[e.cat].label.toLowerCase()}
+                  data-cmmc={cmmcText.toLowerCase()}
+                  data-price={priceText.toLowerCase()}
+                  style={`border-left: 3px solid ${c.border}`}
+                >
+                  <td>
+                    <span class="table-sym" style={`background:${c.fill};border-color:${c.border};color:${c.text}`}>{e.s}</span>
+                    <strong>{e.name}</strong>
+                  </td>
+                  <td><span class="cat-chip" style={`background:${c.fill};color:${c.text};border-color:${c.border}`}>{c.label}</span></td>
+                  <td set:html={e.cmmc} />
+                  <td set:html={e.price} />
+                  <td>
+                    {e.url && e.url.startsWith('https://') ? (
+                      <a href={e.url} target="_blank" rel="noopener noreferrer" class="source-link" onclick="event.stopPropagation()">↗</a>
+                    ) : <span>—</span>}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
       <div class="mobile-view" id="mobile-view">
         <p class="mobile-hint">Tap a firm for details. (The full periodic grid is available on larger screens.)</p>
         <div id="mobile-groups" data-md-exclude>
@@ -141,6 +189,7 @@ const jsonLd = JSON.stringify({
                     <button type="button" class={'mobile-cell' + (e.gap ? ' gap' : '')} style={`border-color:${c.border};color:${c.text}`} data-num={e.n}>
                       <span class="sym" style={`background:${c.fill};border-color:${c.border};color:${c.text}`}>{e.s}</span>
                       <span>{e.name}</span>
+                      <span class={'cmmc-chip conf ' + e.conf} set:html={e.cmmc} />
                     </button>
                   ))}
                 </div>
@@ -290,6 +339,9 @@ const jsonLd = JSON.stringify({
   }
   .map-body .controls button:hover { background: var(--er-bg); }
   .map-body .controls button:active { transform: scale(0.98); }
+  .map-body .controls button#view-toggle[aria-pressed="true"] {
+    background: var(--er-accent); color: var(--er-paper); border-color: var(--er-accent);
+  }
 
   .map-body .legend { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 0 18px; font-size: 11px; }
   .map-body .legend-item {
@@ -330,6 +382,53 @@ const jsonLd = JSON.stringify({
   .map-body .el.gap .sparkle { position: absolute; top: -1px; left: 2px; font-size: 9px; color: #854F0B; }
   @keyframes er-pulse { 0%,100% { box-shadow: 0 0 0 0 rgba(186,117,23,0.6); } 50% { box-shadow: 0 0 0 5px rgba(186,117,23,0); } }
 
+  /* Table view */
+  .map-body .table-view { display: none; margin: 4px 0 12px; overflow-x: auto; }
+  .map-body[data-view="table"] .table-view { display: block; }
+  .map-body[data-view="table"] .periodic,
+  .map-body[data-view="table"] .series,
+  .map-body[data-view="table"] .series-label { display: none; }
+
+  .map-body .entity-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .map-body .entity-table thead th {
+    text-align: left; padding: 8px 12px;
+    font-family: var(--er-font-mono); font-size: 11px; color: var(--er-mute);
+    text-transform: uppercase; letter-spacing: 0.04em;
+    border-bottom: 2px solid var(--er-rule);
+    white-space: nowrap; cursor: pointer; user-select: none;
+    background: var(--er-paper);
+    position: sticky; top: 0; z-index: 2;
+  }
+  .map-body .entity-table thead th:last-child { cursor: default; }
+  .map-body .entity-table thead th:hover:not(:last-child) { color: var(--er-ink); }
+  .map-body .entity-table thead th .sort-icon { font-size: 10px; opacity: 0.4; margin-left: 2px; }
+  .map-body .entity-table thead th[aria-sort="ascending"] .sort-icon,
+  .map-body .entity-table thead th[aria-sort="descending"] .sort-icon { opacity: 1; color: var(--er-accent); }
+  .map-body .entity-table thead th[aria-sort="ascending"] .sort-icon::after { content: '↑'; }
+  .map-body .entity-table thead th[aria-sort="descending"] .sort-icon::after { content: '↓'; }
+  .map-body .entity-table thead th:not([aria-sort="ascending"]):not([aria-sort="descending"]) .sort-icon::after { content: '↕'; }
+
+  .map-body .table-row { border-bottom: 1px solid var(--er-rule); cursor: pointer; transition: background 0.1s ease; }
+  .map-body .table-row:hover { background: var(--er-bg); }
+  .map-body .table-row.dim { opacity: 0.3; pointer-events: none; }
+  .map-body .table-row.selected { background: #FAEEDA; }
+  .map-body .table-row td { padding: 9px 12px; vertical-align: middle; color: var(--er-ink-soft); }
+  .map-body .table-row td:first-child { color: var(--er-ink); }
+  .map-body .table-row td:first-child > * { vertical-align: middle; }
+  .map-body .table-sym {
+    display: inline-block; font-size: 10px; font-weight: 600;
+    padding: 2px 5px; border-radius: 3px; border: 1px solid;
+    margin-right: 6px; white-space: nowrap;
+  }
+  .map-body .cat-chip {
+    display: inline-block; font-size: 10px; padding: 2px 7px;
+    border-radius: 10px; border: 1px solid; white-space: nowrap;
+  }
+  .map-body .source-link {
+    color: var(--er-accent); text-decoration: none; font-size: 14px; font-weight: 600;
+  }
+  .map-body .source-link:hover { text-decoration: underline; }
+
   .map-body .mobile-view { display: none; }
   .map-body .mobile-view .mobile-hint { font-size: 12px; color: var(--er-mute); margin: 0 0 12px; font-style: italic; }
   .map-body .mobile-view .mobile-cat-group { margin-bottom: 18px; }
@@ -357,6 +456,10 @@ const jsonLd = JSON.stringify({
     border: 1px solid;
     font-size: 11px;
   }
+  .map-body .mobile-view .mobile-cell .cmmc-chip {
+    font-size: 10px; padding: 1px 6px; border-radius: 8px;
+    white-space: nowrap; font-weight: 500; margin-left: 2px;
+  }
   .map-body .mobile-view .mobile-cell.gap { border-style: dashed; }
 
   .map-body .detail {
@@ -379,6 +482,12 @@ const jsonLd = JSON.stringify({
   .map-body .detail-meta { flex: 1; min-width: 0; }
   .map-body .detail-name { font-size: 19px; font-weight: 600; margin: 0; color: var(--er-ink); }
   .map-body .detail-cat { font-size: 13px; color: var(--er-mute); margin: 3px 0 0; }
+  .map-body .detail-source {
+    display: inline-block; margin-top: 4px;
+    font-size: 12px; color: var(--er-accent); text-decoration: none;
+    font-family: var(--er-font-mono);
+  }
+  .map-body .detail-source:hover { text-decoration: underline; }
   .map-body .detail-close {
     cursor: pointer; background: transparent;
     border: var(--er-border); width: 32px; height: 32px;
@@ -436,6 +545,10 @@ const jsonLd = JSON.stringify({
     .map-body .periodic, .map-body .series, .map-body .series-label, .map-body .controls button#reset { display: none; }
     .map-body .mobile-view { display: block; }
     .map-body .legend { font-size: 12px; }
+    /* On mobile, table view replaces mobile view when toggled */
+    .map-body[data-view="table"] .mobile-view { display: none; }
+    .map-body[data-view="table"] .table-view { display: block; }
+    .map-body[data-view="table"] .controls button#reset { display: inline-flex; }
   }
 
   @media print {
@@ -447,9 +560,9 @@ const jsonLd = JSON.stringify({
 </style>
 
 <script>
-  // Interactivity island: filter, search, detail card, Escape-close.
-  // The grid is pre-rendered at build time; this script only wires events
-  // and renders the detail card. Ported from market-map.html's inline IIFE.
+  // Interactivity island: filter, search, detail card, Escape-close, view toggle, sortable columns.
+  // The grid and table are pre-rendered at build time; this script only wires events,
+  // renders the detail card, and handles view/sort state.
   //
   // All rendered HTML is built from the build-time JSON constants below.
   // Search input is matched via String.includes() only — never rendered as
@@ -461,7 +574,7 @@ const jsonLd = JSON.stringify({
   type Entity = {
     n: number; s: string; name: string; cat: string; row: number; col: number;
     target: string; fw: string; cmmc: string; price: string; notes: string;
-    conf: string; gap?: boolean;
+    conf: string; gap?: boolean; url?: string;
   };
   const CATS = data.cats as Record<string, { label: string; fill: string; text: string; border: string }>;
   const E = data.entities as Entity[];
@@ -501,8 +614,13 @@ const jsonLd = JSON.stringify({
   const legend = document.getElementById('legend');
   const searchInput = document.getElementById('search') as HTMLInputElement | null;
   const resetBtn = document.getElementById('reset');
+  const viewToggle = document.getElementById('view-toggle') as HTMLButtonElement | null;
+  const mapBody = document.querySelector('.map-body') as HTMLElement | null;
+  const tableBody = document.querySelector('.entity-table tbody') as HTMLElement | null;
+  const tableHeaders = document.querySelectorAll<HTMLElement>('.entity-table thead th[data-col]');
+
   if (detail && legend && searchInput && resetBtn) {
-    const allCells = document.querySelectorAll<HTMLElement>('.el, .mobile-cell');
+    const allCells = document.querySelectorAll<HTMLElement>('.el, .mobile-cell, .table-row');
     const legendItems = legend.querySelectorAll<HTMLElement>('.legend-item');
     const mobileGroupNodes = document.querySelectorAll<HTMLElement>('.mobile-cat-group');
 
@@ -519,7 +637,6 @@ const jsonLd = JSON.stringify({
       li.addEventListener('click', () => toggleCat(li.dataset.cat ?? null));
     });
 
-    // Compose both filters into one predicate so search and legend can coexist.
     function applyFilters() {
       const q = searchInput!.value.trim().toLowerCase();
       allCells.forEach((node) => {
@@ -552,9 +669,58 @@ const jsonLd = JSON.stringify({
 
     searchInput.addEventListener('input', applyFilters);
 
+    // Sortable columns: click → asc → desc → clear
+    let sortCol: string | null = null;
+    let sortDir: 'asc' | 'desc' = 'asc';
+
+    function restoreOriginalOrder() {
+      if (!tableBody) return;
+      const rows = Array.from(tableBody.querySelectorAll<HTMLElement>('.table-row'));
+      rows.sort((a, b) => Number(a.dataset.num) - Number(b.dataset.num));
+      rows.forEach((r) => tableBody.appendChild(r));
+    }
+
+    tableHeaders.forEach((th) => {
+      th.addEventListener('click', () => {
+        const col = th.dataset.col!;
+        if (sortCol === col) {
+          if (sortDir === 'asc') {
+            sortDir = 'desc';
+          } else {
+            sortCol = null;
+            sortDir = 'asc';
+            tableHeaders.forEach((h) => h.setAttribute('aria-sort', 'none'));
+            restoreOriginalOrder();
+            return;
+          }
+        } else {
+          sortCol = col;
+          sortDir = 'asc';
+        }
+        tableHeaders.forEach((h) => h.setAttribute('aria-sort', 'none'));
+        th.setAttribute('aria-sort', sortDir === 'asc' ? 'ascending' : 'descending');
+
+        if (!tableBody) return;
+        const rows = Array.from(tableBody.querySelectorAll<HTMLElement>('.table-row'));
+        rows.sort((a, b) => {
+          const av = (a.dataset[col] ?? '');
+          const bv = (b.dataset[col] ?? '');
+          return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+        });
+        rows.forEach((r) => tableBody.appendChild(r));
+      });
+
+      th.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); th.click(); }
+      });
+    });
+
     resetBtn.addEventListener('click', () => {
       searchInput!.value = '';
       activeCat = null;
+      sortCol = null;
+      sortDir = 'asc';
+      tableHeaders.forEach((h) => h.setAttribute('aria-sort', 'none'));
       legendItems.forEach((li) => {
         li.classList.remove('dim');
         li.setAttribute('aria-pressed', 'false');
@@ -562,15 +728,25 @@ const jsonLd = JSON.stringify({
       allCells.forEach((node) => node.classList.remove('selected'));
       detail!.classList.remove('show');
       applyFilters();
+      restoreOriginalOrder();
     });
 
-    // Escape closes the detail panel.
     document.addEventListener('keydown', (ev) => {
       if (ev.key !== 'Escape') return;
       if (!detail!.classList.contains('show')) return;
       detail!.classList.remove('show');
       allCells.forEach((node) => node.classList.remove('selected'));
     });
+
+    // View toggle: grid ↔ table
+    if (viewToggle && mapBody) {
+      viewToggle.addEventListener('click', () => {
+        const isTable = mapBody.dataset.view === 'table';
+        mapBody.dataset.view = isTable ? '' : 'table';
+        viewToggle.setAttribute('aria-pressed', String(!isTable));
+        viewToggle.textContent = isTable ? 'Table view' : 'Grid view';
+      });
+    }
 
     function showDetail(e: Entity) {
       allCells.forEach((node) => {
@@ -594,6 +770,16 @@ const jsonLd = JSON.stringify({
       nameP.appendChild(el('span', { class: 'conf ' + e.conf }, [e.conf]));
       meta.appendChild(nameP);
       meta.appendChild(el('p', { class: 'detail-cat' }, [cat.label]));
+      // Official site link — built with el() not htmlFrag(); https:// guard prevents javascript: injection
+      if (e.url && /^https:\/\//.test(e.url)) {
+        const host = e.url.replace(/^https:\/\//, '').replace(/\/.*$/, '');
+        meta.appendChild(el('a', {
+          href: e.url,
+          target: '_blank',
+          rel: 'noopener noreferrer',
+          class: 'detail-source',
+        }, ['↗ ' + host]));
+      }
       header.appendChild(meta);
 
       const closeBtn = el('button', {
@@ -610,7 +796,6 @@ const jsonLd = JSON.stringify({
       d.appendChild(header);
 
       const grid = el('div', { class: 'detail-grid' });
-      // target, cmmc, price, notes may contain HTML entities or footnote markup → fragment
       function field(label: string, value: string, allowHtml: boolean) {
         const f = el('div', { class: 'detail-field' });
         f.appendChild(el('div', { class: 'label' }, [label]));


### PR DESCRIPTION
## Summary

- **Source URLs per entity** — all 89 entities now have a `url` field. Detail card shows `↗ hostname` link built with `el()` (not `htmlFrag()`), `https://` scheme guard, `rel="noopener noreferrer"` on all external links.
- **Table view toggle** — "Table view" button in controls switches between the periodic grid and a full `Name | Category | CMMC L2 fit | Pricing | Source` table. Grid stays the default. On mobile, table view replaces the grouped list.
- **Sortable columns** — click any column header to sort asc → desc → restore original order. `aria-sort` on headers, `data-*` normalized sort keys on rows.
- **Mobile CMMC chip** — existing `.conf` chip added to mobile cells (no layout change).
- **CI allowlist check** — `site/scripts/check-entity-fields.mjs` validates notes/price/cmmc/target HTML and url scheme for all 89 entities. `npm run check:entities`.

## Security notes

- URL field rendered via `el()` + `setAttribute`, never `htmlFrag()` — safe for `href`
- `https://` guard on all external link construction
- `rel="noopener noreferrer"` present on every `target="_blank"` link

## Test plan

- [ ] Grid → Table toggle works; both views respond to search + legend filter
- [ ] Clicking a table row opens the same detail card as clicking a grid cell
- [ ] Detail card shows `↗ hostname` link for entities with a URL; none for entities without
- [ ] Sorting Name/Category/CMMC/Pricing: asc → desc → restore; `aria-sort` updates
- [ ] Mobile: existing mobile-cell gains CMMC chip, layout not broken
- [ ] `npm run check:entities` exits 0
- [ ] `npm run build` (Astro step) exits 0, no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)